### PR TITLE
Add Edit Transaction functionality

### DIFF
--- a/src/main/java/seedu/address/logic/commands/transaction/EditTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/transaction/EditTransactionCommand.java
@@ -20,9 +20,11 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
+import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Person;
 import seedu.address.model.transaction.Amount;
 import seedu.address.model.transaction.Category;
 import seedu.address.model.transaction.DateTime;
@@ -31,7 +33,7 @@ import seedu.address.model.transaction.Name;
 import seedu.address.model.transaction.Transaction;
 import seedu.address.model.transaction.Type;
 
-public class EditTransactionCommand {
+public class EditTransactionCommand extends Command {
 
     public static final String COMMAND_WORD = "edit_transaction";
 
@@ -70,6 +72,27 @@ public class EditTransactionCommand {
 
         this.index = index;
         this.editTransactionDescriptor = new EditTransactionCommand.EditTransactionDescriptor(editTransactionDescriptor);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Transaction> lastShownList = model.getFilteredTransactionList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX); // todo
+        }
+
+        Transaction transactionToEdit = lastShownList.get(index.getZeroBased());
+        Transaction editedTransaction = createEditedTransaction(transactionToEdit, editTransactionDescriptor);
+
+        if (!transactionToEdit.isSameTransaction(editedTransaction) && model.hasTransaction(editedTransaction)) {
+            throw new CommandException(MESSAGE_DUPLICATE_TRANSACTION);
+        }
+
+        model.setTransaction(transactionToEdit, editedTransaction);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(String.format(MESSAGE_EDIT_TRANSACTION_SUCCESS, Messages.formatTransaction(editedTransaction)));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/transaction/EditTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/transaction/EditTransactionCommand.java
@@ -7,24 +7,20 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TRANSACTIONS;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.logic.Messages;
+import seedu.address.logic.UniCashMessages;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.person.Person;
 import seedu.address.model.transaction.Amount;
 import seedu.address.model.transaction.Category;
 import seedu.address.model.transaction.DateTime;
@@ -33,6 +29,9 @@ import seedu.address.model.transaction.Name;
 import seedu.address.model.transaction.Transaction;
 import seedu.address.model.transaction.Type;
 
+/**
+ * Edits the details of an existing transaction in the transactions list.
+ */
 public class EditTransactionCommand extends Command {
 
     public static final String COMMAND_WORD = "edit_transaction";
@@ -57,7 +56,8 @@ public class EditTransactionCommand extends Command {
 
     public static final String MESSAGE_EDIT_TRANSACTION_SUCCESS = "Edited Transaction: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_TRANSACTION = "This transaction already exists in the transactions list.";
+    public static final String MESSAGE_DUPLICATE_TRANSACTION = "This transaction already exists"
+            + " in the transactions list.";
 
     private final Index index;
     private final EditTransactionCommand.EditTransactionDescriptor editTransactionDescriptor;
@@ -66,12 +66,14 @@ public class EditTransactionCommand extends Command {
      * @param index of the transaction in the filtered transaction list to edit
      * @param editTransactionDescriptor details to edit the transaction with
      */
-    public EditTransactionCommand(Index index, EditTransactionCommand.EditTransactionDescriptor editTransactionDescriptor) {
+    public EditTransactionCommand(Index index,
+                                  EditTransactionCommand.EditTransactionDescriptor editTransactionDescriptor) {
         requireNonNull(index);
         requireNonNull(editTransactionDescriptor);
 
         this.index = index;
-        this.editTransactionDescriptor = new EditTransactionCommand.EditTransactionDescriptor(editTransactionDescriptor);
+        this.editTransactionDescriptor = new EditTransactionCommand
+                .EditTransactionDescriptor(editTransactionDescriptor);
     }
 
     @Override
@@ -80,7 +82,7 @@ public class EditTransactionCommand extends Command {
         List<Transaction> lastShownList = model.getFilteredTransactionList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX); // todo
+            throw new CommandException(UniCashMessages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
         }
 
         Transaction transactionToEdit = lastShownList.get(index.getZeroBased());
@@ -91,15 +93,17 @@ public class EditTransactionCommand extends Command {
         }
 
         model.setTransaction(transactionToEdit, editedTransaction);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_TRANSACTION_SUCCESS, Messages.formatTransaction(editedTransaction)));
+        model.updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
+        return new CommandResult(String.format(MESSAGE_EDIT_TRANSACTION_SUCCESS,
+                UniCashMessages.formatTransaction(editedTransaction)));
     }
 
     /**
      * Creates and returns a {@code Transaction} with the details of {@code transactionToEdit}
      * edited with {@code editTransactionDescriptor}.
      */
-    private static Transaction createEditedTransaction(Transaction transactionToEdit, EditTransactionCommand.EditTransactionDescriptor editTransactionDescriptor) {
+    private static Transaction createEditedTransaction(Transaction transactionToEdit, EditTransactionCommand
+            .EditTransactionDescriptor editTransactionDescriptor) {
         assert transactionToEdit != null;
 
         Name updatedName = editTransactionDescriptor.getName().orElse(transactionToEdit.getName());
@@ -109,7 +113,8 @@ public class EditTransactionCommand extends Command {
         Location updatedLocation = editTransactionDescriptor.getLocation().orElse(transactionToEdit.getLocation());
         Type updatedType = editTransactionDescriptor.getType().orElse(transactionToEdit.getType());
 
-        return new Transaction(updatedName, updatedType, updatedAmount, updatedCategory, updatedDateTime, updatedLocation);
+        return new Transaction(updatedName, updatedType, updatedAmount, updatedCategory, updatedDateTime,
+                updatedLocation);
     }
 
     @Override
@@ -228,7 +233,8 @@ public class EditTransactionCommand extends Command {
                 return false;
             }
 
-            EditTransactionCommand.EditTransactionDescriptor otherEditTransactionDescriptor = (EditTransactionCommand.EditTransactionDescriptor) other;
+            EditTransactionCommand.EditTransactionDescriptor otherEditTransactionDescriptor = (EditTransactionCommand
+                    .EditTransactionDescriptor) other;
             return Objects.equals(name, otherEditTransactionDescriptor.name)
                     && Objects.equals(amount, otherEditTransactionDescriptor.amount)
                     && Objects.equals(category, otherEditTransactionDescriptor.category)

--- a/src/main/java/seedu/address/logic/commands/transaction/EditTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/transaction/EditTransactionCommand.java
@@ -1,0 +1,230 @@
+package seedu.address.logic.commands.transaction;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CATEGORY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.transaction.Amount;
+import seedu.address.model.transaction.Category;
+import seedu.address.model.transaction.DateTime;
+import seedu.address.model.transaction.Location;
+import seedu.address.model.transaction.Name;
+import seedu.address.model.transaction.Transaction;
+import seedu.address.model.transaction.Type;
+
+public class EditTransactionCommand {
+
+    public static final String COMMAND_WORD = "edit_transaction";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the transaction identified "
+            + "by the index number used in the displayed transaction list. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_NAME + "NAME] "
+            + "[" + PREFIX_TYPE + "TYPE] "
+            + "[" + PREFIX_AMOUNT + "AMOUNT] "
+            + "[" + PREFIX_CATEGORY + "CATEGORY] "
+            + "[" + PREFIX_DATETIME + "DATETIME] "
+            + "[" + PREFIX_LOCATION + "...\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_NAME + "Buying groceries "
+            + PREFIX_TYPE + "expense "
+            + PREFIX_AMOUNT + "300 "
+            + PREFIX_CATEGORY + "household expenses "
+            + PREFIX_DATETIME + "18-08-2001 19:30 "
+            + PREFIX_LOCATION + "ntuc";
+
+    public static final String MESSAGE_EDIT_TRANSACTION_SUCCESS = "Edited Transaction: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_TRANSACTION = "This transaction already exists in the transactions list.";
+
+    private final Index index;
+    private final EditTransactionCommand.EditTransactionDescriptor editTransactionDescriptor;
+
+    /**
+     * @param index of the transaction in the filtered transaction list to edit
+     * @param editTransactionDescriptor details to edit the transaction with
+     */
+    public EditTransactionCommand(Index index, EditTransactionCommand.EditTransactionDescriptor editTransactionDescriptor) {
+        requireNonNull(index);
+        requireNonNull(editTransactionDescriptor);
+
+        this.index = index;
+        this.editTransactionDescriptor = new EditTransactionCommand.EditTransactionDescriptor(editTransactionDescriptor);
+    }
+
+    /**
+     * Creates and returns a {@code Transaction} with the details of {@code transactionToEdit}
+     * edited with {@code editTransactionDescriptor}.
+     */
+    private static Transaction createEditedTransaction(Transaction transactionToEdit, EditTransactionCommand.EditTransactionDescriptor editTransactionDescriptor) {
+        assert transactionToEdit != null;
+
+        Name updatedName = editTransactionDescriptor.getName().orElse(transactionToEdit.getName());
+        Amount updatedAmount = editTransactionDescriptor.getAmount().orElse(transactionToEdit.getAmount());
+        Category updatedCategory = editTransactionDescriptor.getCategory().orElse(transactionToEdit.getCategory());
+        DateTime updatedDateTime = editTransactionDescriptor.getDateTime().orElse(transactionToEdit.getDateTime());
+        Location updatedLocation = editTransactionDescriptor.getLocation().orElse(transactionToEdit.getLocation());
+        Type updatedType = editTransactionDescriptor.getType().orElse(transactionToEdit.getType());
+
+        return new Transaction(updatedName, updatedType, updatedAmount, updatedCategory, updatedDateTime, updatedLocation);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditTransactionCommand)) {
+            return false;
+        }
+
+        EditTransactionCommand otherEditTransactionCommand = (EditTransactionCommand) other;
+        return index.equals(otherEditTransactionCommand.index)
+                && editTransactionDescriptor.equals(otherEditTransactionCommand.editTransactionDescriptor);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("index", index)
+                .add("editTransactionDescriptor", editTransactionDescriptor)
+                .toString();
+    }
+
+    /**
+     * Stores the details to edit the transaction with. Each non-empty field value will replace the
+     * corresponding field value of the transaction.
+     */
+    public static class EditTransactionDescriptor {
+        private Name name;
+        private Amount amount;
+        private Category category;
+        private DateTime datetime;
+        private Location location;
+        private Type type;
+
+        public EditTransactionDescriptor() {}
+
+        /**
+         * Copy constructor.
+         */
+        public EditTransactionDescriptor(EditTransactionCommand.EditTransactionDescriptor toCopy) {
+            setName(toCopy.name);
+            setAmount(toCopy.amount);
+            setCategory(toCopy.category);
+            setDateTime(toCopy.datetime);
+            setLocation(toCopy.location);
+            setType(toCopy.type);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(name, amount, category, datetime, location, type);
+        }
+
+        public void setName(Name name) {
+            this.name = name;
+        }
+
+        public Optional<Name> getName() {
+            return Optional.ofNullable(name);
+        }
+
+        public void setAmount(Amount amount) {
+            this.amount = amount;
+        }
+
+        public Optional<Amount> getAmount() {
+            return Optional.ofNullable(amount);
+        }
+
+        public void setCategory(Category category) {
+            this.category = category;
+        }
+
+        public Optional<Category> getCategory() {
+            return Optional.ofNullable(category);
+        }
+
+        public void setDateTime(DateTime datetime) {
+            this.datetime = datetime;
+        }
+
+        public Optional<DateTime> getDateTime() {
+            return Optional.ofNullable(datetime);
+        }
+
+        public void setLocation(Location location) {
+            this.location = location;
+        }
+
+        public Optional<Location> getLocation() {
+            return Optional.ofNullable(location);
+        }
+
+        public void setType(Type type) {
+            this.type = type;
+        }
+
+        public Optional<Type> getType() {
+            return Optional.ofNullable(type);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditTransactionCommand.EditTransactionDescriptor)) {
+                return false;
+            }
+
+            EditTransactionCommand.EditTransactionDescriptor otherEditTransactionDescriptor = (EditTransactionCommand.EditTransactionDescriptor) other;
+            return Objects.equals(name, otherEditTransactionDescriptor.name)
+                    && Objects.equals(amount, otherEditTransactionDescriptor.amount)
+                    && Objects.equals(category, otherEditTransactionDescriptor.category)
+                    && Objects.equals(datetime, otherEditTransactionDescriptor.datetime)
+                    && Objects.equals(location, otherEditTransactionDescriptor.location)
+                    && Objects.equals(type, otherEditTransactionDescriptor.type);
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .add("name", name)
+                    .add("amount", amount)
+                    .add("category", category)
+                    .add("datetime", datetime)
+                    .add("location", location)
+                    .add("type", type)
+                    .toString();
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/transaction/EditTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/transaction/EditTransactionCommand.java
@@ -88,10 +88,6 @@ public class EditTransactionCommand extends Command {
         Transaction transactionToEdit = lastShownList.get(index.getZeroBased());
         Transaction editedTransaction = createEditedTransaction(transactionToEdit, editTransactionDescriptor);
 
-        if (!transactionToEdit.isSameTransaction(editedTransaction) && model.hasTransaction(editedTransaction)) {
-            throw new CommandException(MESSAGE_DUPLICATE_TRANSACTION);
-        }
-
         model.setTransaction(transactionToEdit, editedTransaction);
         model.updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
         return new CommandResult(String.format(MESSAGE_EDIT_TRANSACTION_SUCCESS,

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,13 +18,12 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.transaction.AddTransactionCommand;
+import seedu.address.logic.commands.transaction.DeleteTransactionCommand;
 import seedu.address.logic.commands.transaction.EditTransactionCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.transaction.AddTransactionCommandParser;
-import seedu.address.logic.parser.transaction.EditTransactionCommandParser;
-import seedu.address.logic.commands.transaction.DeleteTransactionCommand;
 import seedu.address.logic.parser.transaction.DeleteTransactionCommandParser;
-
+import seedu.address.logic.parser.transaction.EditTransactionCommandParser;
 
 /**
  * Parses user input.

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,8 +18,10 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.transaction.AddTransactionCommand;
+import seedu.address.logic.commands.transaction.EditTransactionCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.transaction.AddTransactionCommandParser;
+import seedu.address.logic.parser.transaction.EditTransactionCommandParser;
 
 /**
  * Parses user input.
@@ -81,6 +83,9 @@ public class AddressBookParser {
 
         case AddTransactionCommand.COMMAND_WORD:
             return new AddTransactionCommandParser().parse(arguments);
+
+        case EditTransactionCommand.COMMAND_WORD:
+            return new EditTransactionCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/transaction/EditTransactionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/transaction/EditTransactionCommandParser.java
@@ -1,0 +1,8 @@
+package seedu.address.logic.parser.transaction;
+
+import seedu.address.logic.commands.transaction.AddTransactionCommand;
+import seedu.address.logic.parser.Parser;
+
+public class EditTransactionCommandParser implements Parser<AddTransactionCommand> {
+
+}

--- a/src/main/java/seedu/address/logic/parser/transaction/EditTransactionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/transaction/EditTransactionCommandParser.java
@@ -73,7 +73,6 @@ public class EditTransactionCommandParser implements Parser<EditTransactionComma
             editTransactionDescriptor.setLocation(
                     ParserUtil.parseLocation(argMultimap.getValue(PREFIX_LOCATION).get()));
         }
-        //parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 
         if (!editTransactionDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);

--- a/src/main/java/seedu/address/logic/parser/transaction/EditTransactionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/transaction/EditTransactionCommandParser.java
@@ -1,8 +1,85 @@
 package seedu.address.logic.parser.transaction;
 
-import seedu.address.logic.commands.transaction.AddTransactionCommand;
-import seedu.address.logic.parser.Parser;
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CATEGORY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
-public class EditTransactionCommandParser implements Parser<AddTransactionCommand> {
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.transaction.EditTransactionCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EditTransactionCommand object
+ */
+public class EditTransactionCommandParser implements Parser<EditTransactionCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditTransactionCommand
+     * and returns an EditTransactionCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public EditTransactionCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TYPE, PREFIX_AMOUNT, PREFIX_DATETIME,
+                        PREFIX_CATEGORY, PREFIX_LOCATION);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditTransactionCommand.MESSAGE_USAGE), pe);
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_TYPE, PREFIX_AMOUNT, PREFIX_DATETIME,
+                PREFIX_CATEGORY, PREFIX_LOCATION);
+
+        EditTransactionCommand.EditTransactionDescriptor editTransactionDescriptor = new EditTransactionCommand
+                .EditTransactionDescriptor();
+
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            editTransactionDescriptor.setName(
+                    ParserUtil.parseTransactionName(argMultimap.getValue(PREFIX_NAME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_TYPE).isPresent()) {
+            editTransactionDescriptor.setType(
+                    ParserUtil.parseType(argMultimap.getValue(PREFIX_TYPE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_AMOUNT).isPresent()) {
+            editTransactionDescriptor.setAmount(
+                    ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get()));
+        }
+        if (argMultimap.getValue(PREFIX_DATETIME).isPresent()) {
+            editTransactionDescriptor.setDateTime(
+                    ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_DATETIME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_CATEGORY).isPresent()) {
+            editTransactionDescriptor.setCategory(
+                    ParserUtil.parseCategory(argMultimap.getValue(PREFIX_CATEGORY).get()));
+        }
+        if (argMultimap.getValue(PREFIX_LOCATION).isPresent()) {
+            editTransactionDescriptor.setLocation(
+                    ParserUtil.parseLocation(argMultimap.getValue(PREFIX_LOCATION).get()));
+        }
+        //parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
+
+        if (!editTransactionDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditTransactionCommand(index, editTransactionDescriptor);
+    }
 
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -80,6 +80,13 @@ public interface Model {
      */
     void setPerson(Person target, Person editedPerson);
 
+    /**
+     * Replaces the given transaction {@code target} with {@code editedTransaction}.
+     * {@code target} must exist in the transaction list.
+     * The transaction identity of {@code editedTransaction} must not be the same as another existing transaction.
+     */
+    void setTransaction(Transaction target, Transaction editedTransaction);
+
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -140,6 +140,13 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void setTransaction(Transaction target, Transaction editedTransaction) {
+        requireAllNonNull(target, editedTransaction);
+
+        uniCash.setTransaction(target, editedTransaction);
+    }
+
+    @Override
     public ReadOnlyUniCash getUniCash() {
         return uniCash;
     }

--- a/src/main/java/seedu/address/model/transaction/Transaction.java
+++ b/src/main/java/seedu/address/model/transaction/Transaction.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.Objects;
 
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.model.person.Person;
 
 /**
  * Represents a Transaction in the finance tracker.

--- a/src/main/java/seedu/address/model/transaction/Transaction.java
+++ b/src/main/java/seedu/address/model/transaction/Transaction.java
@@ -64,20 +64,6 @@ public class Transaction {
     }
 
     /**
-     * Returns true if both transactions have the same name and dateTime.
-     * This defines a weaker notion of equality between two transactions.
-     */
-    public boolean isSameTransaction(Transaction otherTransaction) {
-        if (otherTransaction == this) {
-            return true;
-        }
-
-        return otherTransaction != null
-                && otherTransaction.getName().equals(getName())
-                && otherTransaction.getDateTime().equals(getDateTime());
-    }
-
-    /**
      * Returns true if both transactions have the same data fields.
      * This defines a stronger notion of equality between two transactions.
      */

--- a/src/main/java/seedu/address/model/transaction/Transaction.java
+++ b/src/main/java/seedu/address/model/transaction/Transaction.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.Objects;
 
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.Person;
 
 /**
  * Represents a Transaction in the finance tracker.
@@ -64,8 +65,22 @@ public class Transaction {
     }
 
     /**
+     * Returns true if both transactions have the same name and dateTime.
+     * This defines a weaker notion of equality between two transactions.
+     */
+    public boolean isSameTransaction(Transaction otherTransaction) {
+        if (otherTransaction == this) {
+            return true;
+        }
+
+        return otherTransaction != null
+                && otherTransaction.getName().equals(getName())
+                && otherTransaction.getDateTime().equals(getDateTime());
+    }
+
+    /**
      * Returns true if both transactions have the same data fields.
-     * This defines a stronger notion of equality between two expenses.
+     * This defines a stronger notion of equality between two transactions.
      */
     @Override
     public boolean equals(Object other) {

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -151,6 +151,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void setTransaction(Transaction target, Transaction editedTransaction) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -80,7 +80,9 @@ public class CommandTestUtil {
     public static final String TYPE_DESC_EXPENSE = " " + PREFIX_TYPE + VALID_TYPE_EXPENSE;
     public static final String TYPE_DESC_INCOME = " " + PREFIX_TYPE + VALID_TYPE_INCOME;
     public static final String CATEGORY_DESC_ENTERTAINMENT = " " + PREFIX_CATEGORY + VALID_CATEGORY_ENTERTAINMENT;
+    public static final String CATEGORY_DESC_NUS = " " + PREFIX_CATEGORY + VALID_CATEGORY_NUS;
     public static final String LOCATION_DESC_ORCHARD = " " + PREFIX_LOCATION + VALID_LOCATION_ORCHARD;
+    public static final String LOCATION_DESC_NUS = " " + PREFIX_LOCATION + VALID_LOCATION_NUS;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.transaction.EditTransactionCommand;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -27,6 +28,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.transaction.Transaction;
 import seedu.address.model.transaction.TransactionNameContainsKeywordsPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
+import seedu.address.testutil.EditTransactionDescriptorBuilder;
 
 /**
  * Contains helper methods for testing commands.
@@ -55,7 +57,9 @@ public class CommandTestUtil {
     public static final String VALID_DATETIME_INTERN = "08-08-2008 08:08";
     public static final String VALID_DATETIME_SHOPPING = "01-02-2008 11:08";
     public static final String VALID_CATEGORY_ENTERTAINMENT = "entertainment";
+    public static final String VALID_CATEGORY_NUS = "Teaching Assistant";
     public static final String VALID_LOCATION_ORCHARD = "orchard";
+    public static final String VALID_LOCATION_NUS = "NUS";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
@@ -95,6 +99,8 @@ public class CommandTestUtil {
 
     public static final EditCommand.EditPersonDescriptor DESC_AMY;
     public static final EditCommand.EditPersonDescriptor DESC_BOB;
+    public static final EditTransactionCommand.EditTransactionDescriptor DESC_NUS;
+    public static final EditTransactionCommand.EditTransactionDescriptor DESC_SHOPPING;
 
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
@@ -103,6 +109,13 @@ public class CommandTestUtil {
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+        DESC_NUS = new EditTransactionDescriptorBuilder().withName(VALID_TRANSACTION_NAME_NUS)
+                .withAmount(VALID_AMOUNT_NUS).withType(VALID_TYPE_INCOME).withCategory(VALID_CATEGORY_NUS)
+                .withDateTime(VALID_DATETIME_NUS).withLocation(VALID_LOCATION_NUS).build();
+        DESC_SHOPPING = new EditTransactionDescriptorBuilder().withName(VALID_TRANSACTION_NAME_SHOPPING)
+                .withCategory(VALID_CATEGORY_ENTERTAINMENT).withAmount(VALID_AMOUNT_SHOPPING)
+                .withType(VALID_TYPE_EXPENSE).withDateTime(VALID_DATETIME_SHOPPING).withLocation(VALID_LOCATION_ORCHARD)
+                .build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/transaction/AddTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/transaction/AddTransactionCommandTest.java
@@ -153,6 +153,11 @@ public class AddTransactionCommandTest {
         }
 
         @Override
+        public void setTransaction(Transaction target, Transaction editedTransaction) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/transaction/EditTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/transaction/EditTransactionCommandTest.java
@@ -1,0 +1,193 @@
+package seedu.address.logic.commands.transaction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_NUS;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_SHOPPING;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TRANSACTION_NAME_NUS;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_AMOUNT_NUS;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATETIME_NUS;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showTransactionAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TRANSACTION;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_TRANSACTION;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalTransactions.getTypicalUniCash;
+
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.UniCashMessages;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.transaction.EditTransactionCommand.EditTransactionDescriptor;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UniCash;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.transaction.Transaction;
+import seedu.address.testutil.EditTransactionDescriptorBuilder;
+import seedu.address.testutil.TransactionBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for EditTransactionCommand.
+ */
+public class EditTransactionCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalUniCash());
+
+    @Test
+    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        Transaction editedTransaction = new TransactionBuilder().build();
+        EditTransactionCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(editedTransaction).build();
+        EditTransactionCommand editTransactionCommand = new EditTransactionCommand(INDEX_FIRST_TRANSACTION, descriptor);
+
+        String expectedMessage = String.format(EditTransactionCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, UniCashMessages.formatTransaction(editedTransaction));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
+                new UserPrefs(), getTypicalUniCash());
+        expectedModel.setTransaction(model.getFilteredTransactionList().get(0), editedTransaction);
+
+        assertCommandSuccess(editTransactionCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        Index indexLastTransaction = Index.fromOneBased(model.getFilteredTransactionList().size());
+        Transaction lastTransaction = model.getFilteredTransactionList().get(indexLastTransaction.getZeroBased());
+
+        TransactionBuilder transactionInList = new TransactionBuilder(lastTransaction);
+        Transaction editedTransaction = transactionInList.withName(VALID_TRANSACTION_NAME_NUS).withAmount(VALID_AMOUNT_NUS)
+                .withDateTime(VALID_DATETIME_NUS).build();
+
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder().withName(VALID_TRANSACTION_NAME_NUS)
+                .withAmount(VALID_AMOUNT_NUS).withDateTime(VALID_DATETIME_NUS).build();
+        EditTransactionCommand editTransactionCommand = new EditTransactionCommand(indexLastTransaction, descriptor);
+
+        String expectedMessage = String.format(EditTransactionCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, UniCashMessages.formatTransaction(editedTransaction));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
+                new UserPrefs(), getTypicalUniCash());
+        expectedModel.setTransaction(lastTransaction, editedTransaction);
+
+        assertCommandSuccess(editTransactionCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noFieldSpecifiedUnfilteredList_success() {
+        EditTransactionCommand editTransactionCommand = new EditTransactionCommand(INDEX_FIRST_TRANSACTION, new EditTransactionDescriptor());
+        Transaction editedTransaction = model.getFilteredTransactionList().get(INDEX_FIRST_TRANSACTION.getZeroBased());
+
+        String expectedMessage = String.format(EditTransactionCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, UniCashMessages.formatTransaction(editedTransaction));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
+                new UserPrefs(), getTypicalUniCash());
+
+        assertCommandSuccess(editTransactionCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showTransactionAtIndex(model, INDEX_FIRST_TRANSACTION);
+
+        Transaction transactionInFilteredList = model.getFilteredTransactionList().get(INDEX_FIRST_TRANSACTION.getZeroBased());
+        Transaction editedTransaction = new TransactionBuilder(transactionInFilteredList).withName(VALID_TRANSACTION_NAME_NUS).build();
+        EditTransactionCommand editTransactionCommand = new EditTransactionCommand(INDEX_FIRST_TRANSACTION,
+                new EditTransactionDescriptorBuilder().withName(VALID_TRANSACTION_NAME_NUS).build());
+
+        String expectedMessage = String.format(EditTransactionCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, UniCashMessages.formatTransaction(editedTransaction));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
+                new UserPrefs(), getTypicalUniCash());
+        expectedModel.setTransaction(model.getFilteredTransactionList().get(0), editedTransaction);
+
+        assertCommandSuccess(editTransactionCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_duplicateTransactionUnfilteredList_failure() {
+        Transaction firstTransaction = model.getFilteredTransactionList().get(INDEX_FIRST_TRANSACTION.getZeroBased());
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(firstTransaction).build();
+        EditTransactionCommand editTransactionCommand = new EditTransactionCommand(INDEX_SECOND_TRANSACTION, descriptor);
+
+        assertCommandFailure(editTransactionCommand, model, EditTransactionCommand.MESSAGE_DUPLICATE_TRANSACTION);
+    }
+
+    @Test
+    public void execute_duplicateTransactionFilteredList_failure() {
+        showTransactionAtIndex(model, INDEX_FIRST_TRANSACTION);
+
+        // edit transaction in filtered list into a duplicate in address book
+        Transaction transactionInList = model.getUniCash().getTransactionList().get(INDEX_SECOND_TRANSACTION.getZeroBased());
+        EditTransactionCommand editTransactionCommand = new EditTransactionCommand(INDEX_FIRST_TRANSACTION,
+                new EditTransactionDescriptorBuilder(transactionInList).build());
+
+        assertCommandFailure(editTransactionCommand, model, EditTransactionCommand.MESSAGE_DUPLICATE_TRANSACTION);
+    }
+
+    @Test
+    public void execute_invalidTransactionIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTransactionList().size() + 1);
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder().withName(VALID_TRANSACTION_NAME_NUS).build();
+        EditTransactionCommand editTransactionCommand = new EditTransactionCommand(outOfBoundIndex, descriptor);
+
+        assertCommandFailure(editTransactionCommand, model, UniCashMessages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list,
+     * but smaller than size of address book
+     */
+    @Test
+    public void execute_invalidTransactionIndexFilteredList_failure() {
+        showTransactionAtIndex(model, INDEX_FIRST_TRANSACTION);
+        Index outOfBoundIndex = INDEX_SECOND_TRANSACTION;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getUniCash().getTransactionList().size());
+
+        EditTransactionCommand editTransactionCommand = new EditTransactionCommand(outOfBoundIndex,
+                new EditTransactionDescriptorBuilder().withName(VALID_TRANSACTION_NAME_NUS).build());
+
+        assertCommandFailure(editTransactionCommand, model, UniCashMessages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final EditTransactionCommand standardCommand = new EditTransactionCommand(INDEX_FIRST_TRANSACTION, DESC_NUS);
+
+        // same values -> returns true
+        EditTransactionDescriptor copyDescriptor = new EditTransactionDescriptor(DESC_NUS);
+        EditTransactionCommand commandWithSameValues = new EditTransactionCommand(INDEX_FIRST_TRANSACTION, copyDescriptor);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new EditTransactionCommand(INDEX_SECOND_TRANSACTION, DESC_NUS)));
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new EditTransactionCommand(INDEX_FIRST_TRANSACTION, DESC_SHOPPING)));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index index = Index.fromOneBased(1);
+        EditTransactionDescriptor editTransactionDescriptor = new EditTransactionDescriptor();
+        EditTransactionCommand editTransactionCommand = new EditTransactionCommand(index, editTransactionDescriptor);
+        String expected = EditTransactionCommand.class.getCanonicalName() + "{index=" + index + ", editTransactionDescriptor="
+                + editTransactionDescriptor + "}";
+        assertEquals(expected, editTransactionCommand.toString());
+    }
+
+}
+

--- a/src/test/java/seedu/address/logic/commands/transaction/EditTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/transaction/EditTransactionCommandTest.java
@@ -180,12 +180,14 @@ public class EditTransactionCommandTest {
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
+        assertTrue(copyDescriptor.equals(copyDescriptor));
         assertTrue(standardCommand.equals(standardCommand));
 
         // null -> returns false
         assertFalse(standardCommand.equals(null));
 
         // different types -> returns false
+        assertFalse(copyDescriptor.equals(standardCommand));
         assertFalse(standardCommand.equals(new ClearCommand()));
 
         // different index -> returns false

--- a/src/test/java/seedu/address/logic/commands/transaction/EditTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/transaction/EditTransactionCommandTest.java
@@ -5,9 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_NUS;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_SHOPPING;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TRANSACTION_NAME_NUS;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_AMOUNT_NUS;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DATETIME_NUS;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TRANSACTION_NAME_NUS;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showTransactionAtIndex;
@@ -18,7 +18,6 @@ import static seedu.address.testutil.TypicalTransactions.getTypicalUniCash;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.UniCashMessages;
 import seedu.address.logic.commands.ClearCommand;
@@ -26,7 +25,6 @@ import seedu.address.logic.commands.transaction.EditTransactionCommand.EditTrans
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
-import seedu.address.model.UniCash;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.transaction.Transaction;
 import seedu.address.testutil.EditTransactionDescriptorBuilder;
@@ -42,10 +40,12 @@ public class EditTransactionCommandTest {
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Transaction editedTransaction = new TransactionBuilder().build();
-        EditTransactionCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(editedTransaction).build();
+        EditTransactionCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(
+                editedTransaction).build();
         EditTransactionCommand editTransactionCommand = new EditTransactionCommand(INDEX_FIRST_TRANSACTION, descriptor);
 
-        String expectedMessage = String.format(EditTransactionCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, UniCashMessages.formatTransaction(editedTransaction));
+        String expectedMessage = String.format(EditTransactionCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS,
+                UniCashMessages.formatTransaction(editedTransaction));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
                 new UserPrefs(), getTypicalUniCash());
@@ -60,14 +60,19 @@ public class EditTransactionCommandTest {
         Transaction lastTransaction = model.getFilteredTransactionList().get(indexLastTransaction.getZeroBased());
 
         TransactionBuilder transactionInList = new TransactionBuilder(lastTransaction);
-        Transaction editedTransaction = transactionInList.withName(VALID_TRANSACTION_NAME_NUS).withAmount(VALID_AMOUNT_NUS)
+        Transaction editedTransaction = transactionInList
+                .withName(VALID_TRANSACTION_NAME_NUS)
+                .withAmount(VALID_AMOUNT_NUS)
                 .withDateTime(VALID_DATETIME_NUS).build();
 
-        EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder().withName(VALID_TRANSACTION_NAME_NUS)
-                .withAmount(VALID_AMOUNT_NUS).withDateTime(VALID_DATETIME_NUS).build();
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()
+                .withName(VALID_TRANSACTION_NAME_NUS)
+                .withAmount(VALID_AMOUNT_NUS)
+                .withDateTime(VALID_DATETIME_NUS).build();
         EditTransactionCommand editTransactionCommand = new EditTransactionCommand(indexLastTransaction, descriptor);
 
-        String expectedMessage = String.format(EditTransactionCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, UniCashMessages.formatTransaction(editedTransaction));
+        String expectedMessage = String.format(EditTransactionCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS,
+                UniCashMessages.formatTransaction(editedTransaction));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
                 new UserPrefs(), getTypicalUniCash());
@@ -78,10 +83,12 @@ public class EditTransactionCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditTransactionCommand editTransactionCommand = new EditTransactionCommand(INDEX_FIRST_TRANSACTION, new EditTransactionDescriptor());
+        EditTransactionCommand editTransactionCommand = new EditTransactionCommand(INDEX_FIRST_TRANSACTION,
+                new EditTransactionDescriptor());
         Transaction editedTransaction = model.getFilteredTransactionList().get(INDEX_FIRST_TRANSACTION.getZeroBased());
 
-        String expectedMessage = String.format(EditTransactionCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, UniCashMessages.formatTransaction(editedTransaction));
+        String expectedMessage = String.format(EditTransactionCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS,
+                UniCashMessages.formatTransaction(editedTransaction));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
                 new UserPrefs(), getTypicalUniCash());
@@ -93,12 +100,15 @@ public class EditTransactionCommandTest {
     public void execute_filteredList_success() {
         showTransactionAtIndex(model, INDEX_FIRST_TRANSACTION);
 
-        Transaction transactionInFilteredList = model.getFilteredTransactionList().get(INDEX_FIRST_TRANSACTION.getZeroBased());
-        Transaction editedTransaction = new TransactionBuilder(transactionInFilteredList).withName(VALID_TRANSACTION_NAME_NUS).build();
+        Transaction transactionInFilteredList = model.getFilteredTransactionList()
+                .get(INDEX_FIRST_TRANSACTION.getZeroBased());
+        Transaction editedTransaction = new TransactionBuilder(transactionInFilteredList)
+                .withName(VALID_TRANSACTION_NAME_NUS).build();
         EditTransactionCommand editTransactionCommand = new EditTransactionCommand(INDEX_FIRST_TRANSACTION,
                 new EditTransactionDescriptorBuilder().withName(VALID_TRANSACTION_NAME_NUS).build());
 
-        String expectedMessage = String.format(EditTransactionCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, UniCashMessages.formatTransaction(editedTransaction));
+        String expectedMessage = String.format(EditTransactionCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS,
+                UniCashMessages.formatTransaction(editedTransaction));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
                 new UserPrefs(), getTypicalUniCash());
@@ -111,7 +121,8 @@ public class EditTransactionCommandTest {
     public void execute_duplicateTransactionUnfilteredList_failure() {
         Transaction firstTransaction = model.getFilteredTransactionList().get(INDEX_FIRST_TRANSACTION.getZeroBased());
         EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(firstTransaction).build();
-        EditTransactionCommand editTransactionCommand = new EditTransactionCommand(INDEX_SECOND_TRANSACTION, descriptor);
+        EditTransactionCommand editTransactionCommand = new EditTransactionCommand(INDEX_SECOND_TRANSACTION,
+                descriptor);
 
         assertCommandFailure(editTransactionCommand, model, EditTransactionCommand.MESSAGE_DUPLICATE_TRANSACTION);
     }
@@ -121,7 +132,8 @@ public class EditTransactionCommandTest {
         showTransactionAtIndex(model, INDEX_FIRST_TRANSACTION);
 
         // edit transaction in filtered list into a duplicate in address book
-        Transaction transactionInList = model.getUniCash().getTransactionList().get(INDEX_SECOND_TRANSACTION.getZeroBased());
+        Transaction transactionInList = model.getUniCash().getTransactionList()
+                .get(INDEX_SECOND_TRANSACTION.getZeroBased());
         EditTransactionCommand editTransactionCommand = new EditTransactionCommand(INDEX_FIRST_TRANSACTION,
                 new EditTransactionDescriptorBuilder(transactionInList).build());
 
@@ -131,10 +143,12 @@ public class EditTransactionCommandTest {
     @Test
     public void execute_invalidTransactionIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTransactionList().size() + 1);
-        EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder().withName(VALID_TRANSACTION_NAME_NUS).build();
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()
+                .withName(VALID_TRANSACTION_NAME_NUS).build();
         EditTransactionCommand editTransactionCommand = new EditTransactionCommand(outOfBoundIndex, descriptor);
 
-        assertCommandFailure(editTransactionCommand, model, UniCashMessages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
+        assertCommandFailure(editTransactionCommand, model,
+                UniCashMessages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
     }
 
     /**
@@ -151,7 +165,8 @@ public class EditTransactionCommandTest {
         EditTransactionCommand editTransactionCommand = new EditTransactionCommand(outOfBoundIndex,
                 new EditTransactionDescriptorBuilder().withName(VALID_TRANSACTION_NAME_NUS).build());
 
-        assertCommandFailure(editTransactionCommand, model, UniCashMessages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
+        assertCommandFailure(editTransactionCommand, model,
+                UniCashMessages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
     }
 
     @Test
@@ -160,7 +175,8 @@ public class EditTransactionCommandTest {
 
         // same values -> returns true
         EditTransactionDescriptor copyDescriptor = new EditTransactionDescriptor(DESC_NUS);
-        EditTransactionCommand commandWithSameValues = new EditTransactionCommand(INDEX_FIRST_TRANSACTION, copyDescriptor);
+        EditTransactionCommand commandWithSameValues = new EditTransactionCommand(INDEX_FIRST_TRANSACTION,
+                copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -184,8 +200,8 @@ public class EditTransactionCommandTest {
         Index index = Index.fromOneBased(1);
         EditTransactionDescriptor editTransactionDescriptor = new EditTransactionDescriptor();
         EditTransactionCommand editTransactionCommand = new EditTransactionCommand(index, editTransactionDescriptor);
-        String expected = EditTransactionCommand.class.getCanonicalName() + "{index=" + index + ", editTransactionDescriptor="
-                + editTransactionDescriptor + "}";
+        String expected = EditTransactionCommand.class.getCanonicalName()
+                + "{index=" + index + ", editTransactionDescriptor=" + editTransactionDescriptor + "}";
         assertEquals(expected, editTransactionCommand.toString());
     }
 

--- a/src/test/java/seedu/address/logic/commands/transaction/EditTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/transaction/EditTransactionCommandTest.java
@@ -118,29 +118,6 @@ public class EditTransactionCommandTest {
     }
 
     @Test
-    public void execute_duplicateTransactionUnfilteredList_failure() {
-        Transaction firstTransaction = model.getFilteredTransactionList().get(INDEX_FIRST_TRANSACTION.getZeroBased());
-        EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(firstTransaction).build();
-        EditTransactionCommand editTransactionCommand = new EditTransactionCommand(INDEX_SECOND_TRANSACTION,
-                descriptor);
-
-        assertCommandFailure(editTransactionCommand, model, EditTransactionCommand.MESSAGE_DUPLICATE_TRANSACTION);
-    }
-
-    @Test
-    public void execute_duplicateTransactionFilteredList_failure() {
-        showTransactionAtIndex(model, INDEX_FIRST_TRANSACTION);
-
-        // edit transaction in filtered list into a duplicate in address book
-        Transaction transactionInList = model.getUniCash().getTransactionList()
-                .get(INDEX_SECOND_TRANSACTION.getZeroBased());
-        EditTransactionCommand editTransactionCommand = new EditTransactionCommand(INDEX_FIRST_TRANSACTION,
-                new EditTransactionDescriptorBuilder(transactionInList).build());
-
-        assertCommandFailure(editTransactionCommand, model, EditTransactionCommand.MESSAGE_DUPLICATE_TRANSACTION);
-    }
-
-    @Test
     public void execute_invalidTransactionIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTransactionList().size() + 1);
         EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -26,12 +26,14 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.transaction.AddTransactionCommand;
 import seedu.address.logic.commands.transaction.ClearTransactionsCommand;
 import seedu.address.logic.commands.transaction.DeleteTransactionCommand;
+import seedu.address.logic.commands.transaction.EditTransactionCommand;
 import seedu.address.logic.commands.transaction.GetTotalExpenditureCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.model.transaction.Transaction;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
+import seedu.address.testutil.EditTransactionDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
 import seedu.address.testutil.TransactionBuilder;
@@ -118,6 +120,16 @@ public class AddressBookParserTest {
         assertTrue(parser.parseCommand(ClearTransactionsCommand.COMMAND_WORD) instanceof ClearTransactionsCommand);
         assertTrue(parser.parseCommand(ClearTransactionsCommand.COMMAND_WORD + " 3")
                 instanceof ClearTransactionsCommand);
+    }
+
+    @Test
+    public void parseCommand_editTransaction() throws Exception {
+        Transaction transaction = new TransactionBuilder().build();
+        EditTransactionCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(transaction).build();
+        String input = EditTransactionCommand.COMMAND_WORD + " " + INDEX_FIRST_TRANSACTION.getOneBased() + " ";
+        input += TransactionUtil.getEditTransactionDescriptorDetails(descriptor);
+        EditTransactionCommand command = (EditTransactionCommand) parser.parseCommand(input);
+        assertEquals(new EditTransactionCommand(INDEX_FIRST_TRANSACTION, descriptor), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -125,7 +125,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_editTransaction() throws Exception {
         Transaction transaction = new TransactionBuilder().build();
-        EditTransactionCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(transaction).build();
+        EditTransactionCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(transaction)
+                .build();
         String input = EditTransactionCommand.COMMAND_WORD + " " + INDEX_FIRST_TRANSACTION.getOneBased() + " ";
         input += TransactionUtil.getEditTransactionDescriptorDetails(descriptor);
         EditTransactionCommand command = (EditTransactionCommand) parser.parseCommand(input);

--- a/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
@@ -32,8 +32,8 @@ public class CommandParserTestUtil {
         try {
             parser.parse(userInput);
             throw new AssertionError("The expected ParseException was not thrown.");
-        } catch (ParseException pe) {
-            assertEquals(expectedMessage, pe.getMessage());
+        } catch (ParseException | IllegalArgumentException e) {
+            assertEquals(expectedMessage, e.getMessage());
         }
     }
 }

--- a/src/test/java/seedu/address/logic/parser/transaction/EditTransactionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/transaction/EditTransactionCommandParserTest.java
@@ -1,0 +1,223 @@
+package seedu.address.logic.parser.transaction;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.AMOUNT_DESC_INTERN;
+import static seedu.address.logic.commands.CommandTestUtil.AMOUNT_DESC_NUS;
+import static seedu.address.logic.commands.CommandTestUtil.CATEGORY_DESC_ENTERTAINMENT;
+import static seedu.address.logic.commands.CommandTestUtil.CATEGORY_DESC_NUS;
+import static seedu.address.logic.commands.CommandTestUtil.DATETIME_DESC_INTERN;
+import static seedu.address.logic.commands.CommandTestUtil.DATETIME_DESC_NUS;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_AMOUNT_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_CATEGORY_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATETIME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_LOCATION_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TRANSACTION_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TYPE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.LOCATION_DESC_NUS;
+import static seedu.address.logic.commands.CommandTestUtil.LOCATION_DESC_ORCHARD;
+import static seedu.address.logic.commands.CommandTestUtil.TRANSACTION_NAME_DESC_NUS;
+import static seedu.address.logic.commands.CommandTestUtil.TYPE_DESC_EXPENSE;
+import static seedu.address.logic.commands.CommandTestUtil.TYPE_DESC_INCOME;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_AMOUNT_INTERN;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_AMOUNT_NUS;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_CATEGORY_NUS;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATETIME_INTERN;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATETIME_NUS;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOCATION_NUS;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TRANSACTION_NAME_NUS;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TYPE_INCOME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CATEGORY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TRANSACTION;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_TRANSACTION;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_TRANSACTION;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.UniCashMessages;
+import seedu.address.logic.commands.transaction.EditTransactionCommand;
+import seedu.address.model.transaction.Amount;
+import seedu.address.model.transaction.Category;
+import seedu.address.model.transaction.DateTime;
+import seedu.address.model.transaction.Location;
+import seedu.address.model.transaction.Name;
+import seedu.address.model.transaction.Type;
+import seedu.address.testutil.EditTransactionDescriptorBuilder;
+
+public class EditTransactionCommandParserTest {
+
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditTransactionCommand.MESSAGE_USAGE);
+
+    private EditTransactionCommandParser parser = new EditTransactionCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no index specified
+        assertParseFailure(parser, VALID_TRANSACTION_NAME_NUS, MESSAGE_INVALID_FORMAT);
+
+        // no field specified
+        assertParseFailure(parser, "1", EditTransactionCommand.MESSAGE_NOT_EDITED);
+
+        // no index and no field specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+        // negative index
+        assertParseFailure(parser, "-5" + TRANSACTION_NAME_DESC_NUS, MESSAGE_INVALID_FORMAT);
+
+        // zero index
+        assertParseFailure(parser, "0" + TRANSACTION_NAME_DESC_NUS, MESSAGE_INVALID_FORMAT);
+
+        // invalid arguments being parsed as preamble
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+
+        // invalid prefix being parsed as preamble
+        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        assertParseFailure(parser,
+                "1" + INVALID_TRANSACTION_NAME_DESC,
+                Name.MESSAGE_CONSTRAINTS); // invalid name
+        assertParseFailure(parser,
+                "1" + INVALID_AMOUNT_DESC,
+                Amount.MESSAGE_CONSTRAINTS); // invalid amount
+        assertParseFailure(parser,
+                "1" + INVALID_CATEGORY_DESC,
+                Category.MESSAGE_CONSTRAINTS); // invalid category
+        assertParseFailure(parser,
+                "1" + INVALID_DATETIME_DESC,
+                DateTime.MESSAGE_CONSTRAINTS); // invalid datetime
+        assertParseFailure(parser,
+                "1" + INVALID_LOCATION_DESC,
+                Location.MESSAGE_CONSTRAINTS); // invalid location
+        assertParseFailure(parser,
+                "1" + INVALID_TYPE_DESC,
+                Type.MESSAGE_CONSTRAINTS); // invalid type
+
+        // invalid amount followed by valid category
+        assertParseFailure(parser,
+                "1" + INVALID_AMOUNT_DESC + CATEGORY_DESC_ENTERTAINMENT,
+                Amount.MESSAGE_CONSTRAINTS);
+
+        // multiple invalid values, but only the first invalid value is captured
+        assertParseFailure(parser,
+                "1" + INVALID_TRANSACTION_NAME_DESC + INVALID_CATEGORY_DESC + VALID_AMOUNT_INTERN
+                        + VALID_DATETIME_INTERN,
+                Name.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_allFieldsSpecified_success() {
+        Index targetIndex = INDEX_SECOND_TRANSACTION;
+        String userInput = targetIndex.getOneBased() + AMOUNT_DESC_NUS + LOCATION_DESC_NUS + TYPE_DESC_INCOME
+                + CATEGORY_DESC_NUS + DATETIME_DESC_NUS + TRANSACTION_NAME_DESC_NUS;
+
+        EditTransactionCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()
+                .withName(VALID_TRANSACTION_NAME_NUS)
+                .withAmount(VALID_AMOUNT_NUS).withCategory(VALID_CATEGORY_NUS).withLocation(VALID_LOCATION_NUS)
+                .withDateTime(VALID_DATETIME_NUS).withType(VALID_TYPE_INCOME).build();
+        EditTransactionCommand expectedTransactionCommand = new EditTransactionCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedTransactionCommand);
+    }
+
+    @Test
+    public void parse_someFieldsSpecified_success() {
+        Index targetIndex = INDEX_FIRST_TRANSACTION;
+        String userInput = targetIndex.getOneBased() + AMOUNT_DESC_INTERN + CATEGORY_DESC_NUS;
+
+        EditTransactionCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()
+                .withAmount(VALID_AMOUNT_INTERN)
+                .withCategory(VALID_CATEGORY_NUS).build();
+        EditTransactionCommand expectedTransactionCommand = new EditTransactionCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedTransactionCommand);
+    }
+
+    @Test
+    public void parse_oneFieldSpecified_success() {
+        // name
+        Index targetIndex = INDEX_THIRD_TRANSACTION;
+        String userInput = targetIndex.getOneBased() + TRANSACTION_NAME_DESC_NUS;
+        EditTransactionCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()
+                .withName(VALID_TRANSACTION_NAME_NUS).build();
+        EditTransactionCommand expectedCommand = new EditTransactionCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // amount
+        userInput = targetIndex.getOneBased() + AMOUNT_DESC_NUS;
+        descriptor = new EditTransactionDescriptorBuilder().withAmount(VALID_AMOUNT_NUS).build();
+        expectedCommand = new EditTransactionCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // category
+        userInput = targetIndex.getOneBased() + CATEGORY_DESC_NUS;
+        descriptor = new EditTransactionDescriptorBuilder().withCategory(VALID_CATEGORY_NUS).build();
+        expectedCommand = new EditTransactionCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // datetime
+        userInput = targetIndex.getOneBased() + DATETIME_DESC_NUS;
+        descriptor = new EditTransactionDescriptorBuilder().withDateTime(VALID_DATETIME_NUS).build();
+        expectedCommand = new EditTransactionCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // location
+        userInput = targetIndex.getOneBased() + LOCATION_DESC_NUS;
+        descriptor = new EditTransactionDescriptorBuilder().withLocation(VALID_LOCATION_NUS).build();
+        expectedCommand = new EditTransactionCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // type
+        userInput = targetIndex.getOneBased() + TYPE_DESC_INCOME;
+        descriptor = new EditTransactionDescriptorBuilder().withType(VALID_TYPE_INCOME).build();
+        expectedCommand = new EditTransactionCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleRepeatedFields_failure() {
+        // More extensive testing of duplicate parameter detections is done in
+        // AddTransactionCommandParserTest#parse_repeatedNonTagValue_failure()
+
+        // valid followed by invalid
+        Index targetIndex = INDEX_FIRST_TRANSACTION;
+        String userInput = targetIndex.getOneBased() + LOCATION_DESC_NUS + INVALID_LOCATION_DESC;
+
+        assertParseFailure(parser, userInput, UniCashMessages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION));
+
+        // invalid followed by valid
+        userInput = targetIndex.getOneBased() + INVALID_LOCATION_DESC + LOCATION_DESC_NUS;
+
+        assertParseFailure(parser, userInput, UniCashMessages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION));
+
+        // mulltiple valid fields repeated
+        userInput = targetIndex.getOneBased() + LOCATION_DESC_NUS + TYPE_DESC_INCOME + AMOUNT_DESC_NUS
+                + CATEGORY_DESC_NUS + DATETIME_DESC_NUS + LOCATION_DESC_NUS + TYPE_DESC_INCOME + AMOUNT_DESC_NUS
+                + CATEGORY_DESC_NUS + DATETIME_DESC_NUS + LOCATION_DESC_ORCHARD + TYPE_DESC_EXPENSE + AMOUNT_DESC_INTERN
+                + CATEGORY_DESC_ENTERTAINMENT + DATETIME_DESC_INTERN;
+
+        assertParseFailure(parser, userInput,
+                UniCashMessages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION, PREFIX_TYPE, PREFIX_AMOUNT,
+                        PREFIX_DATETIME, PREFIX_CATEGORY));
+
+        // multiple invalid values
+        userInput = targetIndex.getOneBased() + INVALID_LOCATION_DESC + INVALID_CATEGORY_DESC + INVALID_DATETIME_DESC
+                + INVALID_LOCATION_DESC + INVALID_CATEGORY_DESC + INVALID_DATETIME_DESC;
+
+        assertParseFailure(parser, userInput,
+                UniCashMessages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION, PREFIX_CATEGORY, PREFIX_DATETIME));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/transaction/EditTransactionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/transaction/EditTransactionCommandParserTest.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser.transaction;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import seedu.address.logic.commands.CommandTestUtil;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
@@ -17,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.UniCashMessages;
+import seedu.address.logic.commands.CommandTestUtil;
 import seedu.address.logic.commands.transaction.EditTransactionCommand;
 import seedu.address.model.transaction.Amount;
 import seedu.address.model.transaction.Category;
@@ -173,12 +173,14 @@ public class EditTransactionCommandParserTest {
 
         // valid followed by invalid
         Index targetIndex = INDEX_FIRST_TRANSACTION;
-        String userInput = targetIndex.getOneBased() + CommandTestUtil.LOCATION_DESC_NUS + CommandTestUtil.INVALID_LOCATION_DESC;
+        String userInput = targetIndex.getOneBased() + CommandTestUtil.LOCATION_DESC_NUS
+                + CommandTestUtil.INVALID_LOCATION_DESC;
 
         assertParseFailure(parser, userInput, UniCashMessages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION));
 
         // invalid followed by valid
-        userInput = targetIndex.getOneBased() + CommandTestUtil.INVALID_LOCATION_DESC + CommandTestUtil.LOCATION_DESC_NUS;
+        userInput = targetIndex.getOneBased() + CommandTestUtil.INVALID_LOCATION_DESC
+                + CommandTestUtil.LOCATION_DESC_NUS;
 
         assertParseFailure(parser, userInput, UniCashMessages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION));
 

--- a/src/test/java/seedu/address/logic/parser/transaction/EditTransactionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/transaction/EditTransactionCommandParserTest.java
@@ -1,31 +1,7 @@
 package seedu.address.logic.parser.transaction;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.CommandTestUtil.AMOUNT_DESC_INTERN;
-import static seedu.address.logic.commands.CommandTestUtil.AMOUNT_DESC_NUS;
-import static seedu.address.logic.commands.CommandTestUtil.CATEGORY_DESC_ENTERTAINMENT;
-import static seedu.address.logic.commands.CommandTestUtil.CATEGORY_DESC_NUS;
-import static seedu.address.logic.commands.CommandTestUtil.DATETIME_DESC_INTERN;
-import static seedu.address.logic.commands.CommandTestUtil.DATETIME_DESC_NUS;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_AMOUNT_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_CATEGORY_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATETIME_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_LOCATION_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_TRANSACTION_NAME_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_TYPE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.LOCATION_DESC_NUS;
-import static seedu.address.logic.commands.CommandTestUtil.LOCATION_DESC_ORCHARD;
-import static seedu.address.logic.commands.CommandTestUtil.TRANSACTION_NAME_DESC_NUS;
-import static seedu.address.logic.commands.CommandTestUtil.TYPE_DESC_EXPENSE;
-import static seedu.address.logic.commands.CommandTestUtil.TYPE_DESC_INCOME;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_AMOUNT_INTERN;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_AMOUNT_NUS;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_CATEGORY_NUS;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_DATETIME_INTERN;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_DATETIME_NUS;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_LOCATION_NUS;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TRANSACTION_NAME_NUS;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TYPE_INCOME;
+import seedu.address.logic.commands.CommandTestUtil;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
@@ -60,7 +36,7 @@ public class EditTransactionCommandParserTest {
     @Test
     public void parse_missingParts_failure() {
         // no index specified
-        assertParseFailure(parser, VALID_TRANSACTION_NAME_NUS, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, CommandTestUtil.VALID_TRANSACTION_NAME_NUS, MESSAGE_INVALID_FORMAT);
 
         // no field specified
         assertParseFailure(parser, "1", EditTransactionCommand.MESSAGE_NOT_EDITED);
@@ -72,10 +48,10 @@ public class EditTransactionCommandParserTest {
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + TRANSACTION_NAME_DESC_NUS, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-5" + CommandTestUtil.TRANSACTION_NAME_DESC_NUS, MESSAGE_INVALID_FORMAT);
 
         // zero index
-        assertParseFailure(parser, "0" + TRANSACTION_NAME_DESC_NUS, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0" + CommandTestUtil.TRANSACTION_NAME_DESC_NUS, MESSAGE_INVALID_FORMAT);
 
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
@@ -87,46 +63,49 @@ public class EditTransactionCommandParserTest {
     @Test
     public void parse_invalidValue_failure() {
         assertParseFailure(parser,
-                "1" + INVALID_TRANSACTION_NAME_DESC,
+                "1" + CommandTestUtil.INVALID_TRANSACTION_NAME_DESC,
                 Name.MESSAGE_CONSTRAINTS); // invalid name
         assertParseFailure(parser,
-                "1" + INVALID_AMOUNT_DESC,
+                "1" + CommandTestUtil.INVALID_AMOUNT_DESC,
                 Amount.MESSAGE_CONSTRAINTS); // invalid amount
         assertParseFailure(parser,
-                "1" + INVALID_CATEGORY_DESC,
+                "1" + CommandTestUtil.INVALID_CATEGORY_DESC,
                 Category.MESSAGE_CONSTRAINTS); // invalid category
         assertParseFailure(parser,
-                "1" + INVALID_DATETIME_DESC,
+                "1" + CommandTestUtil.INVALID_DATETIME_DESC,
                 DateTime.MESSAGE_CONSTRAINTS); // invalid datetime
         assertParseFailure(parser,
-                "1" + INVALID_LOCATION_DESC,
+                "1" + CommandTestUtil.INVALID_LOCATION_DESC,
                 Location.MESSAGE_CONSTRAINTS); // invalid location
         assertParseFailure(parser,
-                "1" + INVALID_TYPE_DESC,
+                "1" + CommandTestUtil.INVALID_TYPE_DESC,
                 Type.MESSAGE_CONSTRAINTS); // invalid type
 
         // invalid amount followed by valid category
         assertParseFailure(parser,
-                "1" + INVALID_AMOUNT_DESC + CATEGORY_DESC_ENTERTAINMENT,
+                "1" + CommandTestUtil.INVALID_AMOUNT_DESC + CommandTestUtil.CATEGORY_DESC_ENTERTAINMENT,
                 Amount.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser,
-                "1" + INVALID_TRANSACTION_NAME_DESC + INVALID_CATEGORY_DESC + VALID_AMOUNT_INTERN
-                        + VALID_DATETIME_INTERN,
+                "1" + CommandTestUtil.INVALID_TRANSACTION_NAME_DESC + CommandTestUtil.INVALID_CATEGORY_DESC
+                        + CommandTestUtil.VALID_AMOUNT_INTERN + CommandTestUtil.VALID_DATETIME_INTERN,
                 Name.MESSAGE_CONSTRAINTS);
     }
 
     @Test
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_TRANSACTION;
-        String userInput = targetIndex.getOneBased() + AMOUNT_DESC_NUS + LOCATION_DESC_NUS + TYPE_DESC_INCOME
-                + CATEGORY_DESC_NUS + DATETIME_DESC_NUS + TRANSACTION_NAME_DESC_NUS;
+        String userInput = targetIndex.getOneBased() + CommandTestUtil.AMOUNT_DESC_NUS
+                + CommandTestUtil.LOCATION_DESC_NUS + CommandTestUtil.TYPE_DESC_INCOME
+                + CommandTestUtil.CATEGORY_DESC_NUS + CommandTestUtil.DATETIME_DESC_NUS
+                + CommandTestUtil.TRANSACTION_NAME_DESC_NUS;
 
         EditTransactionCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()
-                .withName(VALID_TRANSACTION_NAME_NUS)
-                .withAmount(VALID_AMOUNT_NUS).withCategory(VALID_CATEGORY_NUS).withLocation(VALID_LOCATION_NUS)
-                .withDateTime(VALID_DATETIME_NUS).withType(VALID_TYPE_INCOME).build();
+                .withName(CommandTestUtil.VALID_TRANSACTION_NAME_NUS)
+                .withAmount(CommandTestUtil.VALID_AMOUNT_NUS).withCategory(CommandTestUtil.VALID_CATEGORY_NUS)
+                .withLocation(CommandTestUtil.VALID_LOCATION_NUS).withDateTime(CommandTestUtil.VALID_DATETIME_NUS)
+                .withType(CommandTestUtil.VALID_TYPE_INCOME).build();
         EditTransactionCommand expectedTransactionCommand = new EditTransactionCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedTransactionCommand);
@@ -135,11 +114,12 @@ public class EditTransactionCommandParserTest {
     @Test
     public void parse_someFieldsSpecified_success() {
         Index targetIndex = INDEX_FIRST_TRANSACTION;
-        String userInput = targetIndex.getOneBased() + AMOUNT_DESC_INTERN + CATEGORY_DESC_NUS;
+        String userInput = targetIndex.getOneBased() + CommandTestUtil.AMOUNT_DESC_INTERN
+                + CommandTestUtil.CATEGORY_DESC_NUS;
 
         EditTransactionCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()
-                .withAmount(VALID_AMOUNT_INTERN)
-                .withCategory(VALID_CATEGORY_NUS).build();
+                .withAmount(CommandTestUtil.VALID_AMOUNT_INTERN)
+                .withCategory(CommandTestUtil.VALID_CATEGORY_NUS).build();
         EditTransactionCommand expectedTransactionCommand = new EditTransactionCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedTransactionCommand);
@@ -149,39 +129,39 @@ public class EditTransactionCommandParserTest {
     public void parse_oneFieldSpecified_success() {
         // name
         Index targetIndex = INDEX_THIRD_TRANSACTION;
-        String userInput = targetIndex.getOneBased() + TRANSACTION_NAME_DESC_NUS;
+        String userInput = targetIndex.getOneBased() + CommandTestUtil.TRANSACTION_NAME_DESC_NUS;
         EditTransactionCommand.EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()
-                .withName(VALID_TRANSACTION_NAME_NUS).build();
+                .withName(CommandTestUtil.VALID_TRANSACTION_NAME_NUS).build();
         EditTransactionCommand expectedCommand = new EditTransactionCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // amount
-        userInput = targetIndex.getOneBased() + AMOUNT_DESC_NUS;
-        descriptor = new EditTransactionDescriptorBuilder().withAmount(VALID_AMOUNT_NUS).build();
+        userInput = targetIndex.getOneBased() + CommandTestUtil.AMOUNT_DESC_NUS;
+        descriptor = new EditTransactionDescriptorBuilder().withAmount(CommandTestUtil.VALID_AMOUNT_NUS).build();
         expectedCommand = new EditTransactionCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // category
-        userInput = targetIndex.getOneBased() + CATEGORY_DESC_NUS;
-        descriptor = new EditTransactionDescriptorBuilder().withCategory(VALID_CATEGORY_NUS).build();
+        userInput = targetIndex.getOneBased() + CommandTestUtil.CATEGORY_DESC_NUS;
+        descriptor = new EditTransactionDescriptorBuilder().withCategory(CommandTestUtil.VALID_CATEGORY_NUS).build();
         expectedCommand = new EditTransactionCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // datetime
-        userInput = targetIndex.getOneBased() + DATETIME_DESC_NUS;
-        descriptor = new EditTransactionDescriptorBuilder().withDateTime(VALID_DATETIME_NUS).build();
+        userInput = targetIndex.getOneBased() + CommandTestUtil.DATETIME_DESC_NUS;
+        descriptor = new EditTransactionDescriptorBuilder().withDateTime(CommandTestUtil.VALID_DATETIME_NUS).build();
         expectedCommand = new EditTransactionCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // location
-        userInput = targetIndex.getOneBased() + LOCATION_DESC_NUS;
-        descriptor = new EditTransactionDescriptorBuilder().withLocation(VALID_LOCATION_NUS).build();
+        userInput = targetIndex.getOneBased() + CommandTestUtil.LOCATION_DESC_NUS;
+        descriptor = new EditTransactionDescriptorBuilder().withLocation(CommandTestUtil.VALID_LOCATION_NUS).build();
         expectedCommand = new EditTransactionCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // type
-        userInput = targetIndex.getOneBased() + TYPE_DESC_INCOME;
-        descriptor = new EditTransactionDescriptorBuilder().withType(VALID_TYPE_INCOME).build();
+        userInput = targetIndex.getOneBased() + CommandTestUtil.TYPE_DESC_INCOME;
+        descriptor = new EditTransactionDescriptorBuilder().withType(CommandTestUtil.VALID_TYPE_INCOME).build();
         expectedCommand = new EditTransactionCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -193,28 +173,34 @@ public class EditTransactionCommandParserTest {
 
         // valid followed by invalid
         Index targetIndex = INDEX_FIRST_TRANSACTION;
-        String userInput = targetIndex.getOneBased() + LOCATION_DESC_NUS + INVALID_LOCATION_DESC;
+        String userInput = targetIndex.getOneBased() + CommandTestUtil.LOCATION_DESC_NUS + CommandTestUtil.INVALID_LOCATION_DESC;
 
         assertParseFailure(parser, userInput, UniCashMessages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION));
 
         // invalid followed by valid
-        userInput = targetIndex.getOneBased() + INVALID_LOCATION_DESC + LOCATION_DESC_NUS;
+        userInput = targetIndex.getOneBased() + CommandTestUtil.INVALID_LOCATION_DESC + CommandTestUtil.LOCATION_DESC_NUS;
 
         assertParseFailure(parser, userInput, UniCashMessages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION));
 
         // mulltiple valid fields repeated
-        userInput = targetIndex.getOneBased() + LOCATION_DESC_NUS + TYPE_DESC_INCOME + AMOUNT_DESC_NUS
-                + CATEGORY_DESC_NUS + DATETIME_DESC_NUS + LOCATION_DESC_NUS + TYPE_DESC_INCOME + AMOUNT_DESC_NUS
-                + CATEGORY_DESC_NUS + DATETIME_DESC_NUS + LOCATION_DESC_ORCHARD + TYPE_DESC_EXPENSE + AMOUNT_DESC_INTERN
-                + CATEGORY_DESC_ENTERTAINMENT + DATETIME_DESC_INTERN;
+        userInput = targetIndex.getOneBased() + CommandTestUtil.LOCATION_DESC_NUS + CommandTestUtil.TYPE_DESC_INCOME
+                + CommandTestUtil.AMOUNT_DESC_NUS + CommandTestUtil.CATEGORY_DESC_NUS
+                + CommandTestUtil.DATETIME_DESC_NUS + CommandTestUtil.LOCATION_DESC_NUS
+                + CommandTestUtil.TYPE_DESC_INCOME + CommandTestUtil.AMOUNT_DESC_NUS
+                + CommandTestUtil.CATEGORY_DESC_NUS + CommandTestUtil.DATETIME_DESC_NUS
+                + CommandTestUtil.LOCATION_DESC_ORCHARD + CommandTestUtil.TYPE_DESC_EXPENSE
+                + CommandTestUtil.AMOUNT_DESC_INTERN + CommandTestUtil.CATEGORY_DESC_ENTERTAINMENT
+                + CommandTestUtil.DATETIME_DESC_INTERN;
 
         assertParseFailure(parser, userInput,
                 UniCashMessages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION, PREFIX_TYPE, PREFIX_AMOUNT,
                         PREFIX_DATETIME, PREFIX_CATEGORY));
 
         // multiple invalid values
-        userInput = targetIndex.getOneBased() + INVALID_LOCATION_DESC + INVALID_CATEGORY_DESC + INVALID_DATETIME_DESC
-                + INVALID_LOCATION_DESC + INVALID_CATEGORY_DESC + INVALID_DATETIME_DESC;
+        userInput = targetIndex.getOneBased() + CommandTestUtil.INVALID_LOCATION_DESC
+                + CommandTestUtil.INVALID_CATEGORY_DESC + CommandTestUtil.INVALID_DATETIME_DESC
+                + CommandTestUtil.INVALID_LOCATION_DESC + CommandTestUtil.INVALID_CATEGORY_DESC
+                + CommandTestUtil.INVALID_DATETIME_DESC;
 
         assertParseFailure(parser, userInput,
                 UniCashMessages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION, PREFIX_CATEGORY, PREFIX_DATETIME));

--- a/src/test/java/seedu/address/testutil/EditTransactionDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditTransactionDescriptorBuilder.java
@@ -1,0 +1,90 @@
+package seedu.address.testutil;
+
+import seedu.address.logic.commands.transaction.EditTransactionCommand;
+import seedu.address.model.transaction.Amount;
+import seedu.address.model.transaction.Category;
+import seedu.address.model.transaction.DateTime;
+import seedu.address.model.transaction.Location;
+import seedu.address.model.transaction.Name;
+import seedu.address.model.transaction.Transaction;
+import seedu.address.model.transaction.Type;
+
+/**
+ * A utility class to help with building EditTransactionDescriptor objects.
+ */
+public class EditTransactionDescriptorBuilder {
+    private EditTransactionCommand.EditTransactionDescriptor descriptor;
+
+    public EditTransactionDescriptorBuilder() {
+        descriptor = new EditTransactionCommand.EditTransactionDescriptor();
+    }
+
+    public EditTransactionDescriptorBuilder(EditTransactionCommand.EditTransactionDescriptor descriptor) {
+        this.descriptor = new EditTransactionCommand.EditTransactionDescriptor(descriptor);
+    }
+
+    /**
+     * Returns an {@code EditTransactionDescriptor} with fields containing {@code transaction}'s details
+     */
+    public EditTransactionDescriptorBuilder(Transaction transaction) {
+        descriptor = new EditTransactionCommand.EditTransactionDescriptor();
+        descriptor.setName(transaction.getName());
+        descriptor.setAmount(transaction.getAmount());
+        descriptor.setCategory(transaction.getCategory());
+        descriptor.setDateTime(transaction.getDateTime());
+        descriptor.setLocation(transaction.getLocation());
+        descriptor.setType(transaction.getType());
+    }
+
+    /**
+     * Sets the {@code Name} of the {@code EditTransactionDescriptor} that we are building.
+     */
+    public EditTransactionDescriptorBuilder withName(String name) {
+        descriptor.setName(new Name(name));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Amount} of the {@code EditTransactionDescriptor} that we are building.
+     */
+    public EditTransactionDescriptorBuilder withAmount(double amount) {
+        descriptor.setAmount(new Amount(amount));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Category} of the {@code EditTransactionDescriptor} that we are building.
+     */
+    public EditTransactionDescriptorBuilder withCategory(String category) {
+        descriptor.setCategory(new Category(category));
+        return this;
+    }
+
+    /**
+     * Sets the {@code DateTime} of the {@code EditTransactionDescriptor} that we are building.
+     */
+    public EditTransactionDescriptorBuilder withDateTime(String dateTime) {
+        descriptor.setDateTime(new DateTime(dateTime));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Location} of the {@code EditTransactionDescriptor} that we are building.
+     */
+    public EditTransactionDescriptorBuilder withLocation(String location) {
+        descriptor.setLocation(new Location(location));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Type} of the {@code EditTransactionDescriptor} that we are building.
+     */
+    public EditTransactionDescriptorBuilder withType(String type) {
+        descriptor.setType(new Type(type));
+        return this;
+    }
+
+    public EditTransactionCommand.EditTransactionDescriptor build() {
+        return descriptor;
+    }
+}

--- a/src/test/java/seedu/address/testutil/TransactionBuilder.java
+++ b/src/test/java/seedu/address/testutil/TransactionBuilder.java
@@ -13,7 +13,7 @@ import seedu.address.model.transaction.Type;
  */
 public class TransactionBuilder {
 
-    public static final String DEFAULT_NAME = "Amy Bee";
+    public static final String DEFAULT_NAME = "Dog food";
     public static final double DEFAULT_AMOUNT = 123.45;
     public static final String DEFAULT_CATEGORY = "Food";
     public static final String DEFAULT_DATE_TIME = "18-08-2001 10:10";

--- a/src/test/java/seedu/address/testutil/TransactionUtil.java
+++ b/src/test/java/seedu/address/testutil/TransactionUtil.java
@@ -1,21 +1,14 @@
 package seedu.address.testutil;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
-
-import java.util.Set;
 
 import seedu.address.logic.commands.transaction.AddTransactionCommand;
 import seedu.address.logic.commands.transaction.EditTransactionCommand;
-import seedu.address.model.tag.Tag;
 import seedu.address.model.transaction.Transaction;
 
 /**
@@ -45,14 +38,21 @@ public class TransactionUtil {
         return sb.toString();
     }
 
-    public static String getEditTransactionDescriptorDetails(EditTransactionCommand.EditTransactionDescriptor descriptor) {
+    public static String getEditTransactionDescriptorDetails(EditTransactionCommand
+                                                                     .EditTransactionDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
-        descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));
-        descriptor.getType().ifPresent(type -> sb.append(PREFIX_TYPE).append(type.type.getOriginalString()).append(" "));
-        descriptor.getAmount().ifPresent(amount -> sb.append(PREFIX_AMOUNT).append(amount.amount).append(" "));
-        descriptor.getCategory().ifPresent(category -> sb.append(PREFIX_CATEGORY).append(category.category).append(" "));
-        descriptor.getLocation().ifPresent(location -> sb.append(PREFIX_LOCATION).append(location).append(" "));
-        descriptor.getDateTime().ifPresent(dateTime -> sb.append(PREFIX_DATETIME).append(dateTime.originalString()).append(" "));
+        descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName)
+                .append(" "));
+        descriptor.getType().ifPresent(type -> sb.append(PREFIX_TYPE).append(type.type.getOriginalString())
+                .append(" "));
+        descriptor.getAmount().ifPresent(amount -> sb.append(PREFIX_AMOUNT).append(amount.amount)
+                .append(" "));
+        descriptor.getCategory().ifPresent(category -> sb.append(PREFIX_CATEGORY).append(category.category)
+                .append(" "));
+        descriptor.getLocation().ifPresent(location -> sb.append(PREFIX_LOCATION).append(location)
+                .append(" "));
+        descriptor.getDateTime().ifPresent(dateTime -> sb.append(PREFIX_DATETIME).append(dateTime.originalString())
+                .append(" "));
         return sb.toString();
     }
 }

--- a/src/test/java/seedu/address/testutil/TransactionUtil.java
+++ b/src/test/java/seedu/address/testutil/TransactionUtil.java
@@ -1,13 +1,21 @@
 package seedu.address.testutil;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
+import java.util.Set;
+
 import seedu.address.logic.commands.transaction.AddTransactionCommand;
+import seedu.address.logic.commands.transaction.EditTransactionCommand;
+import seedu.address.model.tag.Tag;
 import seedu.address.model.transaction.Transaction;
 
 /**
@@ -34,6 +42,17 @@ public class TransactionUtil {
         sb.append(PREFIX_DATETIME + transaction.getDateTime().originalString() + " ");
         sb.append(PREFIX_LOCATION + transaction.getLocation().location + " ");
 
+        return sb.toString();
+    }
+
+    public static String getEditTransactionDescriptorDetails(EditTransactionCommand.EditTransactionDescriptor descriptor) {
+        StringBuilder sb = new StringBuilder();
+        descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));
+        descriptor.getType().ifPresent(type -> sb.append(PREFIX_TYPE).append(type.type.getOriginalString()).append(" "));
+        descriptor.getAmount().ifPresent(amount -> sb.append(PREFIX_AMOUNT).append(amount.amount).append(" "));
+        descriptor.getCategory().ifPresent(category -> sb.append(PREFIX_CATEGORY).append(category.category).append(" "));
+        descriptor.getLocation().ifPresent(location -> sb.append(PREFIX_LOCATION).append(location).append(" "));
+        descriptor.getDateTime().ifPresent(dateTime -> sb.append(PREFIX_DATETIME).append(dateTime.originalString()).append(" "));
         return sb.toString();
     }
 }


### PR DESCRIPTION
The EditTransactionCommand and EditTransactionCommandParser classes have been created. Changes have also been made to AddressBookParser to recognize the command. Unit tests for the two new classes have also been added. Besides the above changes, which should be common for everyone, here are a few additional changes made:

1. `Model.java`: Add the setTransaction method declaration as the EditTransactionCommand requires it
2. `ModelManager.java`: Implement the setTransaction method
3. `Transaction.java`: Add the isSameTransaction method for softer notion of equality between two transactions
4. `AddCommandTest.java` and `AddTransactionCommandTest.java`: Implement the setTransaction method in ModelStub
5. `CommandTestUtil.java`: Add a few more utility variables for testing (VALID_CATEGORY_NUS, VALID_LOCATION_NUS, CATEGORY_DESC_NUS, LOCATION_DESC_NUS, DESC_NUS, DESC_SHOPPING)
6. `CommandParserTestUtil#assertParseFailure`: Handle IllegalArgumentException, besides ParseException