### PR TITLE
Fix GetTotalExpenditure for expense w/ no category

### DIFF
--- a/src/main/java/unicash/logic/commands/GetTotalExpenditureCommand.java
+++ b/src/main/java/unicash/logic/commands/GetTotalExpenditureCommand.java
@@ -47,12 +47,14 @@ public class GetTotalExpenditureCommand extends Command {
         model.updateFilteredTransactionList(transaction -> {
             boolean isExpense = transaction.getType().type.equals(TransactionType.EXPENSE);
             boolean isSameMonth = transaction.getDateTime().getDateTime().getMonthValue() == month;
-            boolean hasCategory = transaction.getCategories().stream().anyMatch(cat -> {
-                if (categoryFilter == null) {
-                    return true;
-                }
-                return cat.equals(categoryFilter);
-            });
+            if (categoryFilter == null) {
+                // No category filter so just get all expenses of the month
+                return isExpense && isSameMonth;
+            }
+
+            // If category filter exists and expense contains no category, it will not have the category
+            // Note: If the stream is empty then false is returned and the predicate is not evaluated.
+            boolean hasCategory = transaction.getCategories().stream().anyMatch(cat -> cat.equals(categoryFilter));
             return isExpense && isSameMonth && hasCategory;
         });
 

--- a/src/test/java/unicash/logic/commands/GetTotalExpenditureCommandTest.java
+++ b/src/test/java/unicash/logic/commands/GetTotalExpenditureCommandTest.java
@@ -70,6 +70,23 @@ public class GetTotalExpenditureCommandTest {
     }
 
     @Test
+    public void execute_expenseWithoutCategory_notIncludedInFilter() throws CommandException {
+        var model = getModel();
+        // This transaction does not contain any categories even if it's in August
+        model.addTransaction(new TransactionBuilder().withCategories().withType("expense").build());
+        model.addTransaction(new TransactionBuilder().withType("expense").withDateTime("18-07-2001 00:00").build());
+        model.addTransaction(new TransactionBuilder().withType("expense").withCategories("Food").build());
+        var command = new GetTotalExpenditureCommand(8, new Category("Food"));
+        command.execute(model);
+        var filteredResult = model.getFilteredTransactionList();
+        assertEquals(1, filteredResult.size());
+        for (var result : filteredResult) {
+            assertEquals(TransactionType.EXPENSE, result.getType().type);
+            assertEquals(8, result.getDateTime().getDateTime().getMonthValue());
+        }
+    }
+
+    @Test
     public void execute_multipleCategoriesOnly_filtersOnlySelectedCategory() throws CommandException {
         var model = getModel();
         model.addTransaction(new TransactionBuilder().withType("expense").withCategories("Food").build());

--- a/src/test/java/unicash/logic/commands/GetTotalExpenditureCommandTest.java
+++ b/src/test/java/unicash/logic/commands/GetTotalExpenditureCommandTest.java
@@ -70,7 +70,7 @@ public class GetTotalExpenditureCommandTest {
     }
 
     @Test
-    public void execute_expenseWithoutCategory_notIncludedInFilter() throws CommandException {
+    public void execute_expenseWithoutCategoryWithCategoryFilter_notIncludedInFilter() throws CommandException {
         var model = getModel();
         // This transaction does not contain any categories even if it's in August
         model.addTransaction(new TransactionBuilder().withCategories().withType("expense").build());
@@ -80,6 +80,24 @@ public class GetTotalExpenditureCommandTest {
         command.execute(model);
         var filteredResult = model.getFilteredTransactionList();
         assertEquals(1, filteredResult.size());
+        for (var result : filteredResult) {
+            assertEquals(TransactionType.EXPENSE, result.getType().type);
+            assertEquals(8, result.getDateTime().getDateTime().getMonthValue());
+        }
+    }
+
+    @Test
+    public void execute_expenseWithoutCategoryWithoutCategoryFilter_includedInFilter() throws CommandException {
+        var model = getModel();
+        // This transaction does not contain any categories even if it's in August
+        // This should be included this round as no category filter is in place
+        model.addTransaction(new TransactionBuilder().withCategories().withType("expense").build());
+        model.addTransaction(new TransactionBuilder().withType("expense").withDateTime("18-07-2001 00:00").build());
+        model.addTransaction(new TransactionBuilder().withType("expense").withCategories("Food").build());
+        var command = new GetTotalExpenditureCommand(8, null);
+        command.execute(model);
+        var filteredResult = model.getFilteredTransactionList();
+        assertEquals(2, filteredResult.size());
         for (var result : filteredResult) {
             assertEquals(TransactionType.EXPENSE, result.getType().type);
             assertEquals(8, result.getDateTime().getDateTime().getMonthValue());


### PR DESCRIPTION
Behavior caused by default behavior of anyMatch where empty stream defaults to false so hasCategory is naively assumed to be false even if category filter does not exist