### PR TITLE
Modify and add tests for add, delete, and find commands

### DIFF
--- a/src/main/java/unicash/logic/commands/FindCommand.java
+++ b/src/main/java/unicash/logic/commands/FindCommand.java
@@ -9,7 +9,7 @@ import unicash.model.transaction.TransactionNameContainsKeywordsPredicate;
 
 /**
  * Finds and lists all transactions in UniCa$h whose name contains any of the argument keywords.
- * Keyword matching is case insensitive.
+ * Keyword matching is case-insensitive.
  */
 public class FindCommand extends Command {
 

--- a/src/test/java/unicash/logic/commands/AddTransactionCommandTest.java
+++ b/src/test/java/unicash/logic/commands/AddTransactionCommandTest.java
@@ -59,7 +59,7 @@ public class AddTransactionCommandTest {
         Transaction nus = new TransactionBuilder().withName("Nus").build();
         Transaction intern = new TransactionBuilder().withName("Intern").build();
         AddTransactionCommand addNusCommand = new AddTransactionCommand(nus);
-        AddTransactionCommand addBobCommand = new AddTransactionCommand(intern);
+        AddTransactionCommand addInternCommand = new AddTransactionCommand(intern);
 
         // same object -> returns true
         assertEquals(addNusCommand, addNusCommand);
@@ -75,7 +75,7 @@ public class AddTransactionCommandTest {
         assertNotEquals(null, addNusCommand);
 
         // different Transaction -> returns false
-        assertNotEquals(addNusCommand, addBobCommand);
+        assertNotEquals(addNusCommand, addInternCommand);
 
         assertFalse(addNusCommand.equals(2));
     }
@@ -163,7 +163,7 @@ public class AddTransactionCommandTest {
     }
 
     /**
-     * A Model stub that contains a single person.
+     * A Model stub that contains a single transaction.
      */
     private class ModelStubWithTransaction extends AddTransactionCommandTest.ModelStub {
         private final Transaction transaction;
@@ -185,7 +185,7 @@ public class AddTransactionCommandTest {
     }
 
     /**
-     * A Model stub that always accept the person being added.
+     * A Model stub that always accept the transaction being added.
      */
     private class ModelStubAcceptingTransactionAdded extends AddTransactionCommandTest.ModelStub {
         final ArrayList<Transaction> transactionsAdded = new ArrayList<>();

--- a/src/test/java/unicash/logic/commands/AddTransactionCommandTest.java
+++ b/src/test/java/unicash/logic/commands/AddTransactionCommandTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static unicash.testutil.Assert.assertThrows;
+import static unicash.testutil.TypicalTransactions.INTERN;
 import static unicash.testutil.TypicalTransactions.NUS;
 
 import java.nio.file.Path;
@@ -56,16 +57,14 @@ public class AddTransactionCommandTest {
 
     @Test
     public void equals() {
-        Transaction nus = new TransactionBuilder().withName("Nus").build();
-        Transaction intern = new TransactionBuilder().withName("Intern").build();
-        AddTransactionCommand addNusCommand = new AddTransactionCommand(nus);
-        AddTransactionCommand addInternCommand = new AddTransactionCommand(intern);
+        AddTransactionCommand addNusCommand = new AddTransactionCommand(NUS);
+        AddTransactionCommand addInternCommand = new AddTransactionCommand(INTERN);
 
         // same object -> returns true
         assertEquals(addNusCommand, addNusCommand);
 
         // same values -> returns true
-        AddTransactionCommand addNusCommandCopy = new AddTransactionCommand(nus);
+        AddTransactionCommand addNusCommandCopy = new AddTransactionCommand(NUS);
         assertEquals(addNusCommand, addNusCommandCopy);
 
         // different types -> returns false

--- a/src/test/java/unicash/logic/commands/CommandTestUtil.java
+++ b/src/test/java/unicash/logic/commands/CommandTestUtil.java
@@ -28,7 +28,7 @@ import unicash.testutil.EditTransactionDescriptorBuilder;
 public class CommandTestUtil {
 
     public static final String VALID_TRANSACTION_NAME_NUS = "Work at NUS";
-    public static final String VALID_TRANSACTION_NAME_INTERN = "Internship";
+    public static final String VALID_TRANSACTION_NAME_INTERN = "Internship work";
     public static final String VALID_TRANSACTION_NAME_SHOPPING = "Shopping";
     public static final String VALID_TYPE_EXPENSE = "expense";
     public static final String VALID_TYPE_INCOME = "income";

--- a/src/test/java/unicash/logic/commands/DeleteTransactionCommandTest.java
+++ b/src/test/java/unicash/logic/commands/DeleteTransactionCommandTest.java
@@ -50,14 +50,12 @@ public class DeleteTransactionCommandTest {
         assertEquals(deleteFirstCommand, deleteFirstCommandCopy);
 
         // different types -> returns false
-        assertNotEquals(1, deleteFirstCommand);
-
         assertFalse(deleteFirstCommand.equals(1));
 
         // null -> returns false
         assertNotEquals(null, deleteFirstCommand);
 
-        // different person -> returns false
+        // different transaction -> returns false
         assertNotEquals(deleteFirstCommand, deleteSecondCommand);
     }
 

--- a/src/test/java/unicash/logic/commands/FindCommandTest.java
+++ b/src/test/java/unicash/logic/commands/FindCommandTest.java
@@ -15,12 +15,10 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import unicash.commons.enums.TransactionType;
 import unicash.model.Model;
 import unicash.model.ModelManager;
 import unicash.model.UniCash;
 import unicash.model.UserPrefs;
-import unicash.model.transaction.Transaction;
 import unicash.model.transaction.TransactionNameContainsKeywordsPredicate;
 
 /**

--- a/src/test/java/unicash/logic/commands/FindCommandTest.java
+++ b/src/test/java/unicash/logic/commands/FindCommandTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static unicash.logic.UniCashMessages.MESSAGE_TRANSACTIONS_LISTED_OVERVIEW;
 import static unicash.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static unicash.testutil.TypicalTransactions.INTERN;
+import static unicash.testutil.TypicalTransactions.NUS;
+import static unicash.testutil.TypicalTransactions.getTypicalUniCash;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -12,10 +15,12 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import unicash.commons.enums.TransactionType;
 import unicash.model.Model;
 import unicash.model.ModelManager;
 import unicash.model.UniCash;
 import unicash.model.UserPrefs;
+import unicash.model.transaction.Transaction;
 import unicash.model.transaction.TransactionNameContainsKeywordsPredicate;
 
 /**
@@ -23,7 +28,9 @@ import unicash.model.transaction.TransactionNameContainsKeywordsPredicate;
  */
 public class FindCommandTest {
     private final Model model = new ModelManager(new UniCash(), new UserPrefs());
+    private final Model modelWithTransactions = new ModelManager(getTypicalUniCash(), new UserPrefs());
     private final Model expectedModel = new ModelManager(new UniCash(), new UserPrefs());
+
     @Test
     public void equals() {
         TransactionNameContainsKeywordsPredicate firstPredicate =
@@ -47,7 +54,7 @@ public class FindCommandTest {
         // null -> returns false
         assertNotEquals(null, findFirstCommand);
 
-        // different person -> returns false
+        // different transaction -> returns false
         assertNotEquals(findFirstCommand, findSecondCommand);
 
         assertFalse(findFirstCommand.equals(3));
@@ -61,6 +68,22 @@ public class FindCommandTest {
         expectedModel.updateFilteredTransactionList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredTransactionList());
+    }
+
+    @Test
+    public void execute_oneKeyword_multipleTransactionsFound() {
+        String expectedMessage = String.format(MESSAGE_TRANSACTIONS_LISTED_OVERVIEW, 2);
+        TransactionNameContainsKeywordsPredicate predicate = preparePredicate("work");
+        FindCommand command = new FindCommand(predicate);
+
+        Model expectedModel = new ModelManager(getTypicalUniCash(), new UserPrefs());
+        expectedModel.updateFilteredTransactionList(predicate);
+
+        assertCommandSuccess(command, modelWithTransactions, expectedMessage, expectedModel);
+
+        var filteredResult = modelWithTransactions.getFilteredTransactionList();
+        assertEquals(filteredResult.get(0), NUS);
+        assertEquals(filteredResult.get(1), INTERN);
     }
 
     @Test

--- a/src/test/java/unicash/logic/parser/DeleteTransactionCommandParserTest.java
+++ b/src/test/java/unicash/logic/parser/DeleteTransactionCommandParserTest.java
@@ -26,12 +26,16 @@ public class DeleteTransactionCommandParserTest {
 
         // Non-integer input
         assertThrows(ParseException.class, () -> parser.parse("a"));
+        assertThrows(ParseException.class, () -> parser.parse("."));
 
         // Negative number
         assertThrows(ParseException.class, () -> parser.parse("-1"));
 
         // Zero as input (assuming indices are 1-based)
         assertThrows(ParseException.class, () -> parser.parse("0"));
+
+        // Float as input (assuming indices are 1-based)
+        assertThrows(ParseException.class, () -> parser.parse("0.5"));
     }
 
 }

--- a/src/test/java/unicash/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/unicash/logic/parser/FindCommandParserTest.java
@@ -20,6 +20,8 @@ public class FindCommandParserTest {
     public void parse_emptyArg_throwsParseException() {
         CommandParserTestUtil.assertParseFailure(parser, "     ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        CommandParserTestUtil.assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/unicash/logic/parser/ParserUtilTest.java
+++ b/src/test/java/unicash/logic/parser/ParserUtilTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static unicash.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static unicash.testutil.Assert.assertThrows;
-import static unicash.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static unicash.testutil.TypicalIndexes.INDEX_FIRST_TRANSACTION;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -55,10 +55,10 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_validInput_success() throws Exception {
         // No whitespaces
-        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("1"));
+        assertEquals(INDEX_FIRST_TRANSACTION, ParserUtil.parseIndex("1"));
 
         // Leading and trailing whitespaces
-        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  "));
+        assertEquals(INDEX_FIRST_TRANSACTION, ParserUtil.parseIndex("  1  "));
     }
 
     @Test

--- a/src/test/java/unicash/model/ModelManagerTest.java
+++ b/src/test/java/unicash/model/ModelManagerTest.java
@@ -135,7 +135,6 @@ public class ModelManagerTest {
 
         assertFalse(modelManager.equals(uniCash));
 
-        // TODO: Replicate this for transaction list
         // different filteredList -> returns false
         String[] keywords = new String[] {"internship"};
         modelManager.updateFilteredTransactionList(

--- a/src/test/java/unicash/model/ModelManagerTest.java
+++ b/src/test/java/unicash/model/ModelManagerTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static unicash.model.Model.PREDICATE_SHOW_ALL_TRANSACTIONS;
 import static unicash.testutil.Assert.assertThrows;
 import static unicash.testutil.TypicalTransactions.BUYING_GROCERIES;
-import static unicash.testutil.TypicalTransactions.INTERN;
 import static unicash.testutil.TypicalTransactions.NUS;
 
 import java.nio.file.Path;
@@ -138,7 +137,7 @@ public class ModelManagerTest {
 
         // TODO: Replicate this for transaction list
         // different filteredList -> returns false
-        String[] keywords = INTERN.getName().fullName.split("\\s+");
+        String[] keywords = new String[] {"internship"};
         modelManager.updateFilteredTransactionList(
                 new TransactionNameContainsKeywordsPredicate(Arrays.asList(keywords))
         );

--- a/src/test/java/unicash/testutil/TypicalIndexes.java
+++ b/src/test/java/unicash/testutil/TypicalIndexes.java
@@ -6,9 +6,6 @@ import unicash.commons.core.index.Index;
  * A utility class containing a list of {@code Index} objects to be used in tests.
  */
 public class TypicalIndexes {
-    public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
-    public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
-    public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
     public static final Index INDEX_FIRST_TRANSACTION = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_TRANSACTION = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_TRANSACTION = Index.fromOneBased(3);

--- a/src/test/java/unicash/testutil/TypicalTransactions.java
+++ b/src/test/java/unicash/testutil/TypicalTransactions.java
@@ -76,11 +76,11 @@ public class TypicalTransactions {
      * Returns a {@code UniCash} with all the typical transactions.
      */
     public static UniCash getTypicalUniCash() {
-        UniCash ab = new UniCash();
+        UniCash uc = new UniCash();
         for (Transaction transaction : getTypicalTransactions()) {
-            ab.addTransaction(transaction);
+            uc.addTransaction(transaction);
         }
-        return ab;
+        return uc;
     }
 
     public static List<Transaction> getTypicalTransactions() {

--- a/src/test/java/unicash/testutil/TypicalTransactions.java
+++ b/src/test/java/unicash/testutil/TypicalTransactions.java
@@ -76,11 +76,11 @@ public class TypicalTransactions {
      * Returns a {@code UniCash} with all the typical transactions.
      */
     public static UniCash getTypicalUniCash() {
-        UniCash uc = new UniCash();
+        UniCash typicalUnicash = new UniCash();
         for (Transaction transaction : getTypicalTransactions()) {
-            uc.addTransaction(transaction);
+            typicalUnicash.addTransaction(transaction);
         }
-        return uc;
+        return typicalUnicash;
     }
 
     public static List<Transaction> getTypicalTransactions() {


### PR DESCRIPTION
Most changes proposed are minor changes such as names (e.g. person --> transaction, addressbook --> unicash).

Here are some other changes proposed:
FindCommandTest now is able to test if the command can filter >1 transactions that contain a keyword. To do this, I modified `CommandTestUtil#VALID_TRANSACTION_NAME_INTERN` from "Internship" to "Internship work". This was done so that now, two transactions contain the keyword "work". The `NUS` transaction contains the word "Work" (uppercase), while the `INTERN` transaction contains the keyword "work" (lowercase). Hence, this test also checks if the find command is case-insensitive, which is the desired behavior.