### PR TITLE
Add Reset Functionality to UniCash

### DIFF
--- a/src/main/java/unicash/logic/commands/ExitCommand.java
+++ b/src/main/java/unicash/logic/commands/ExitCommand.java
@@ -5,7 +5,7 @@ import unicash.model.Model;
 /**
  * Terminates UniCa$h.
  */
-public class ExitCommandUniCash extends Command {
+public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 

--- a/src/main/java/unicash/logic/commands/HelpCommand.java
+++ b/src/main/java/unicash/logic/commands/HelpCommand.java
@@ -5,7 +5,7 @@ import unicash.model.Model;
 /**
  * Format full help instructions for every command for display.
  */
-public class HelpCommandUniCash extends Command {
+public class HelpCommand extends Command {
 
     public static final String COMMAND_WORD = "help";
 

--- a/src/main/java/unicash/logic/commands/HelpCommand.java
+++ b/src/main/java/unicash/logic/commands/HelpCommand.java
@@ -19,5 +19,4 @@ public class HelpCommand extends Command {
     public CommandResult execute(Model model) {
         return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
     }
-    
 }

--- a/src/main/java/unicash/logic/commands/HelpCommand.java
+++ b/src/main/java/unicash/logic/commands/HelpCommand.java
@@ -19,4 +19,5 @@ public class HelpCommand extends Command {
     public CommandResult execute(Model model) {
         return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
     }
+    
 }

--- a/src/main/java/unicash/logic/commands/ResetCommand.java
+++ b/src/main/java/unicash/logic/commands/ResetCommand.java
@@ -10,7 +10,7 @@ import unicash.model.Model;
  * storage data and populating it with the default UniCa$h containing
  * typical transactions from {@code SampleDataUtil}.
  */
-public class ResetUniCashCommand extends Command {
+public class ResetCommand extends Command {
 
     public static final String COMMAND_WORD = "reset_unicash";
     public static final String MESSAGE_SUCCESS =

--- a/src/main/java/unicash/logic/commands/ResetUniCashCommand.java
+++ b/src/main/java/unicash/logic/commands/ResetUniCashCommand.java
@@ -1,0 +1,26 @@
+package unicash.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static unicash.model.util.SampleDataUtil.getSampleUniCash;
+
+import unicash.model.Model;
+
+/**
+ * Resets UniCa$h to initial state by replacing the current UniCa$h
+ * storage data and populating it with the default UniCa$h containing
+ * typical transactions from {@code SampleDataUtil}.
+ */
+public class ResetUniCashCommand extends Command {
+
+    public static final String COMMAND_WORD = "reset_unicash";
+    public static final String MESSAGE_SUCCESS =
+            "UniCa$h has been successfully restored to its original state!";
+
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.setUniCash(getSampleUniCash());
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/unicash/logic/parser/UniCashParser.java
+++ b/src/main/java/unicash/logic/parser/UniCashParser.java
@@ -13,11 +13,12 @@ import unicash.logic.commands.ClearTransactionsCommand;
 import unicash.logic.commands.Command;
 import unicash.logic.commands.DeleteTransactionCommand;
 import unicash.logic.commands.EditTransactionCommand;
-import unicash.logic.commands.ExitCommandUniCash;
+import unicash.logic.commands.ExitCommand;
 import unicash.logic.commands.FindCommand;
 import unicash.logic.commands.GetTotalExpenditureCommand;
-import unicash.logic.commands.HelpCommandUniCash;
+import unicash.logic.commands.HelpCommand;
 import unicash.logic.commands.ListCommand;
+import unicash.logic.commands.ResetUniCashCommand;
 import unicash.logic.parser.exceptions.ParseException;
 
 
@@ -42,7 +43,7 @@ public class UniCashParser {
     public Command parseCommand(String userInput) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommandUniCash.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
         final String commandWord = matcher.group("commandWord").toLowerCase();
@@ -75,11 +76,14 @@ public class UniCashParser {
         case ClearTransactionsCommand.COMMAND_WORD:
             return new ClearTransactionsCommand();
 
-        case HelpCommandUniCash.COMMAND_WORD:
-            return new HelpCommandUniCash();
+        case ResetUniCashCommand.COMMAND_WORD:
+            return new ResetUniCashCommand();
 
-        case ExitCommandUniCash.COMMAND_WORD:
-            return new ExitCommandUniCash();
+        case HelpCommand.COMMAND_WORD:
+            return new HelpCommand();
+
+        case ExitCommand.COMMAND_WORD:
+            return new ExitCommand();
 
 
         default:

--- a/src/main/java/unicash/logic/parser/UniCashParser.java
+++ b/src/main/java/unicash/logic/parser/UniCashParser.java
@@ -18,7 +18,7 @@ import unicash.logic.commands.FindCommand;
 import unicash.logic.commands.GetTotalExpenditureCommand;
 import unicash.logic.commands.HelpCommand;
 import unicash.logic.commands.ListCommand;
-import unicash.logic.commands.ResetUniCashCommand;
+import unicash.logic.commands.ResetCommand;
 import unicash.logic.parser.exceptions.ParseException;
 
 
@@ -76,8 +76,8 @@ public class UniCashParser {
         case ClearTransactionsCommand.COMMAND_WORD:
             return new ClearTransactionsCommand();
 
-        case ResetUniCashCommand.COMMAND_WORD:
-            return new ResetUniCashCommand();
+        case ResetCommand.COMMAND_WORD:
+            return new ResetCommand();
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();

--- a/src/test/java/unicash/logic/commands/ExitCommandTest.java
+++ b/src/test/java/unicash/logic/commands/ExitCommandTest.java
@@ -1,24 +1,25 @@
 package unicash.logic.commands;
 
 import static unicash.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static unicash.logic.commands.HelpCommandUniCash.SHOWING_HELP_MESSAGE;
 
 import org.junit.jupiter.api.Test;
 
 import unicash.model.Model;
 import unicash.model.ModelManager;
 
-public class HelpCommandUniCashTest {
+public class ExitCommandTest {
+
 
     @Test
-    public void execute_help_success() {
+    public void execute_exit_success() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
 
         CommandResult expectedCommandResult =
-                new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+                new CommandResult(ExitCommand.MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
 
-        assertCommandSuccess(new HelpCommandUniCash(), model,
+        assertCommandSuccess(new ExitCommand(), model,
                 expectedCommandResult, expectedModel);
     }
 }
+

--- a/src/test/java/unicash/logic/commands/HelpCommandTest.java
+++ b/src/test/java/unicash/logic/commands/HelpCommandTest.java
@@ -1,25 +1,24 @@
 package unicash.logic.commands;
 
 import static unicash.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static unicash.logic.commands.HelpCommand.SHOWING_HELP_MESSAGE;
 
 import org.junit.jupiter.api.Test;
 
 import unicash.model.Model;
 import unicash.model.ModelManager;
 
-public class ExitCommandUniCashTest {
-
+public class HelpCommandTest {
 
     @Test
-    public void execute_exit_success() {
+    public void execute_help_success() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
 
         CommandResult expectedCommandResult =
-                new CommandResult(ExitCommandUniCash.MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+                new CommandResult(SHOWING_HELP_MESSAGE, true, false);
 
-        assertCommandSuccess(new ExitCommandUniCash(), model,
+        assertCommandSuccess(new HelpCommand(), model,
                 expectedCommandResult, expectedModel);
     }
 }
-

--- a/src/test/java/unicash/logic/commands/ResetCommandTest.java
+++ b/src/test/java/unicash/logic/commands/ResetCommandTest.java
@@ -11,7 +11,7 @@ import unicash.model.UniCash;
 import unicash.model.UserPrefs;
 
 
-public class ResetUniCashCommandTest {
+public class ResetCommandTest {
 
     @Test
     public void execute_emptyUniCash_success() {
@@ -19,8 +19,8 @@ public class ResetUniCashCommandTest {
         Model expectedModel = new ModelManager();
         expectedModel.setUniCash(getSampleUniCash());
 
-        assertCommandSuccess(new ResetUniCashCommand(), model,
-                ResetUniCashCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ResetCommand(), model,
+                ResetCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
@@ -29,8 +29,8 @@ public class ResetUniCashCommandTest {
         Model expectedModel = new ModelManager(new UniCash(), new UserPrefs());
         expectedModel.setUniCash(getSampleUniCash());
 
-        assertCommandSuccess(new ResetUniCashCommand(), model,
-                ResetUniCashCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ResetCommand(), model,
+                ResetCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
 }

--- a/src/test/java/unicash/logic/commands/ResetUniCashCommandTest.java
+++ b/src/test/java/unicash/logic/commands/ResetUniCashCommandTest.java
@@ -1,7 +1,7 @@
 package unicash.logic.commands;
 
 import static unicash.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static unicash.testutil.TypicalTransactions.getTypicalUniCash;
+import static unicash.model.util.SampleDataUtil.getSampleUniCash;
 
 import org.junit.jupiter.api.Test;
 
@@ -11,25 +11,26 @@ import unicash.model.UniCash;
 import unicash.model.UserPrefs;
 
 
-public class ClearTransactionsCommandTest {
+public class ResetUniCashCommandTest {
 
     @Test
     public void execute_emptyUniCash_success() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
+        expectedModel.setUniCash(getSampleUniCash());
 
-        assertCommandSuccess(new ClearTransactionsCommand(), model,
-                ClearTransactionsCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ResetUniCashCommand(), model,
+                ResetUniCashCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_nonEmptyUniCash_success() {
-        Model model = new ModelManager(getTypicalUniCash(), new UserPrefs());
+        Model model = new ModelManager(getSampleUniCash(), new UserPrefs());
         Model expectedModel = new ModelManager(new UniCash(), new UserPrefs());
-        expectedModel.setUniCash(new UniCash());
+        expectedModel.setUniCash(getSampleUniCash());
 
-        assertCommandSuccess(new ClearTransactionsCommand(), model,
-                ClearTransactionsCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ResetUniCashCommand(), model,
+                ResetUniCashCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
 }

--- a/src/test/java/unicash/logic/parser/UniCashParserTest.java
+++ b/src/test/java/unicash/logic/parser/UniCashParserTest.java
@@ -17,11 +17,12 @@ import unicash.logic.commands.AddTransactionCommand;
 import unicash.logic.commands.ClearTransactionsCommand;
 import unicash.logic.commands.DeleteTransactionCommand;
 import unicash.logic.commands.EditTransactionCommand;
-import unicash.logic.commands.ExitCommandUniCash;
+import unicash.logic.commands.ExitCommand;
 import unicash.logic.commands.FindCommand;
 import unicash.logic.commands.GetTotalExpenditureCommand;
-import unicash.logic.commands.HelpCommandUniCash;
+import unicash.logic.commands.HelpCommand;
 import unicash.logic.commands.ListCommand;
+import unicash.logic.commands.ResetUniCashCommand;
 import unicash.logic.parser.exceptions.ParseException;
 import unicash.model.transaction.Transaction;
 import unicash.model.transaction.TransactionNameContainsKeywordsPredicate;
@@ -35,8 +36,8 @@ public class UniCashParserTest {
 
     @Test
     public void parseCommand_exit() throws Exception {
-        assertTrue(parser.parseCommand(ExitCommandUniCash.COMMAND_WORD) instanceof ExitCommandUniCash);
-        assertTrue(parser.parseCommand(ExitCommandUniCash.COMMAND_WORD + " 3") instanceof ExitCommandUniCash);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
     }
 
     @Test
@@ -49,8 +50,8 @@ public class UniCashParserTest {
 
     @Test
     public void parseCommand_help() throws Exception {
-        assertTrue(parser.parseCommand(HelpCommandUniCash.COMMAND_WORD) instanceof HelpCommandUniCash);
-        assertTrue(parser.parseCommand(HelpCommandUniCash.COMMAND_WORD + " 3") instanceof HelpCommandUniCash);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
     }
 
     @Test
@@ -76,10 +77,17 @@ public class UniCashParserTest {
     }
 
     @Test
-    public void parseCommand_clearTransaction() throws Exception {
+    public void parseCommand_clearTransactions() throws Exception {
         assertTrue(parser.parseCommand(ClearTransactionsCommand.COMMAND_WORD) instanceof ClearTransactionsCommand);
         assertTrue(parser.parseCommand(ClearTransactionsCommand.COMMAND_WORD + " 3")
                 instanceof ClearTransactionsCommand);
+    }
+
+    @Test
+    public void parseCommand_resetUniCashCommand() throws Exception {
+        assertTrue(parser.parseCommand(ResetUniCashCommand.COMMAND_WORD) instanceof ResetUniCashCommand);
+        assertTrue(parser.parseCommand(ResetUniCashCommand.COMMAND_WORD + " 3")
+                instanceof ResetUniCashCommand);
     }
 
     @Test
@@ -108,22 +116,22 @@ public class UniCashParserTest {
     @Test
     public void parseCommand_helpUniCash() throws Exception {
         assertTrue(parser.parseCommand(
-                HelpCommandUniCash.COMMAND_WORD) instanceof HelpCommandUniCash);
+                HelpCommand.COMMAND_WORD) instanceof HelpCommand);
         assertTrue(parser.parseCommand(
-                HelpCommandUniCash.COMMAND_WORD + " 3") instanceof HelpCommandUniCash);
+                HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
     }
 
     @Test
     public void parseCommand_exitUniCash() throws Exception {
         assertTrue(parser.parseCommand(
-                ExitCommandUniCash.COMMAND_WORD) instanceof ExitCommandUniCash);
+                ExitCommand.COMMAND_WORD) instanceof ExitCommand);
         assertTrue(parser.parseCommand(
-                ExitCommandUniCash.COMMAND_WORD + " 3") instanceof ExitCommandUniCash);
+                ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
     }
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
-        var message = String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommandUniCash.MESSAGE_USAGE);
+        var message = String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE);
         assertThrows(ParseException.class, message, () -> parser.parseCommand(""));
     }
 

--- a/src/test/java/unicash/logic/parser/UniCashParserTest.java
+++ b/src/test/java/unicash/logic/parser/UniCashParserTest.java
@@ -22,7 +22,7 @@ import unicash.logic.commands.FindCommand;
 import unicash.logic.commands.GetTotalExpenditureCommand;
 import unicash.logic.commands.HelpCommand;
 import unicash.logic.commands.ListCommand;
-import unicash.logic.commands.ResetUniCashCommand;
+import unicash.logic.commands.ResetCommand;
 import unicash.logic.parser.exceptions.ParseException;
 import unicash.model.transaction.Transaction;
 import unicash.model.transaction.TransactionNameContainsKeywordsPredicate;
@@ -85,9 +85,9 @@ public class UniCashParserTest {
 
     @Test
     public void parseCommand_resetUniCashCommand() throws Exception {
-        assertTrue(parser.parseCommand(ResetUniCashCommand.COMMAND_WORD) instanceof ResetUniCashCommand);
-        assertTrue(parser.parseCommand(ResetUniCashCommand.COMMAND_WORD + " 3")
-                instanceof ResetUniCashCommand);
+        assertTrue(parser.parseCommand(ResetCommand.COMMAND_WORD) instanceof ResetCommand);
+        assertTrue(parser.parseCommand(ResetCommand.COMMAND_WORD + " 3")
+                instanceof ResetCommand);
     }
 
     @Test


### PR DESCRIPTION
### Overview
Currently, UniCash starts populated with sample data.

However, once this data is cleared, there is no way to restore the sample data apart from manually deleting the unicash.json storage, and then restarting Unicash to trigger its population mechanism, which would require the user to bypass the App and access its storage files directly.

Let's fix this minor issue by allowing the user, and any possible testers of the UniCash application to restore UniCash to its initial default state such that any data-modification actions or tests can be conveniently reversed.

### Changes made:
- HelpCommandUniCash and ExitCommandUniCash refactored to HelpCommand and ExitCommand 
    - Since we're mostly done migrating from AddressBook to UniCash, the suffixes are redundant
- Add ResetCommand Functionality
    - Main classes affected: ResetCommand, ResetCommandTest, UniCashParser, UniCashParser Test

### Future considerations: 
- Refer to google docs.