### PR TITLE
Modify UI and reverse TransactionListPanel

### DIFF
--- a/src/main/java/unicash/logic/UniCashMessages.java
+++ b/src/main/java/unicash/logic/UniCashMessages.java
@@ -38,7 +38,8 @@ public class UniCashMessages {
      */
     public static String formatTransaction(Transaction transaction) {
         final StringBuilder builder = new StringBuilder();
-        builder.append(transaction.getName())
+        builder.append("Name: ")
+                .append(transaction.getName())
                 .append("; \nType: ")
                 .append(transaction.getType())
                 .append("; \nAmount: ")

--- a/src/main/java/unicash/logic/commands/AddTransactionCommand.java
+++ b/src/main/java/unicash/logic/commands/AddTransactionCommand.java
@@ -30,11 +30,11 @@ public class AddTransactionCommand extends Command {
             + CliSyntax.PREFIX_NAME + "Buying groceries "
             + CliSyntax.PREFIX_TYPE + "expense "
             + CliSyntax.PREFIX_AMOUNT + "300 "
-            + CliSyntax.PREFIX_DATETIME + "18-08-2001 19:30 "
+            + CliSyntax.PREFIX_DATETIME + "18-08-2023 19:30 "
             + CliSyntax.PREFIX_LOCATION + "ntuc "
             + CliSyntax.PREFIX_CATEGORY + "household";
 
-    public static final String MESSAGE_SUCCESS = "New transaction added: %1$s";
+    public static final String MESSAGE_SUCCESS = "New transaction added: \n\n%1$s";
 
     private final Transaction toAdd;
 

--- a/src/main/java/unicash/logic/commands/DeleteTransactionCommand.java
+++ b/src/main/java/unicash/logic/commands/DeleteTransactionCommand.java
@@ -25,7 +25,7 @@ public class DeleteTransactionCommand extends Command {
             + "\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_TRANSACTION_SUCCESS = "Deleted Transaction: %1$s";
+    public static final String MESSAGE_DELETE_TRANSACTION_SUCCESS = "Deleted Transaction:\n\n%1$s";
 
     private final Index targetIndex;
 

--- a/src/main/java/unicash/logic/commands/EditTransactionCommand.java
+++ b/src/main/java/unicash/logic/commands/EditTransactionCommand.java
@@ -37,16 +37,16 @@ public class EditTransactionCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the transaction identified "
             + "by the index number used in the displayed transaction list."
-            + "Existing values will be overwritten by the input values!\n"
-            + "\n"
+            + "Existing values will be overwritten by the input values!"
+            + "\n\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_TYPE + "TYPE] "
             + "[" + PREFIX_AMOUNT + "AMOUNT] "
             + "[" + PREFIX_DATETIME + "DATETIME] "
             + "[" + PREFIX_LOCATION + "LOCATION]"
-            + "[" + PREFIX_CATEGORY + "CATEGORY]...\n"
-            + "\n"
+            + "[" + PREFIX_CATEGORY + "CATEGORY]..."
+            + "\n\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_NAME + "Buying groceries "
             + PREFIX_TYPE + "expense "
@@ -56,7 +56,7 @@ public class EditTransactionCommand extends Command {
             + PREFIX_CATEGORY + "household expenses ";
 
 
-    public static final String MESSAGE_EDIT_TRANSACTION_SUCCESS = "Edited Transaction: %1$s";
+    public static final String MESSAGE_EDIT_TRANSACTION_SUCCESS = "Edited Transaction: \n\n%1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
 
     private final Index index;

--- a/src/main/java/unicash/ui/CommandBox.java
+++ b/src/main/java/unicash/ui/CommandBox.java
@@ -2,6 +2,7 @@ package unicash.ui;
 
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
+import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.Region;
 import unicash.logic.Logic;

--- a/src/main/java/unicash/ui/CommandBox.java
+++ b/src/main/java/unicash/ui/CommandBox.java
@@ -2,7 +2,6 @@ package unicash.ui;
 
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
-import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.Region;
 import unicash.logic.Logic;

--- a/src/main/java/unicash/ui/TransactionListPanel.java
+++ b/src/main/java/unicash/ui/TransactionListPanel.java
@@ -13,7 +13,8 @@ import unicash.commons.core.LogsCenter;
 import unicash.model.transaction.Transaction;
 
 /**
- * Panel containing the list of persons.
+ * TransactionListPanel contains the main list of Transactions to be
+ * displayed via the Main Window of the application.
  */
 public class TransactionListPanel extends UiPart<Region> {
     private static final String FXML = "TransactionListPanel.fxml";
@@ -31,16 +32,20 @@ public class TransactionListPanel extends UiPart<Region> {
         transactionListView.setCellFactory(
                 listView -> new TransactionListViewCell(transactionList));
 
-        // Binds items property of the ListView to an ObservableList. Whenever the list is
-        // updated (like reversing its order), the ListView will reflect the changes. The
-        // item of the ListView is kept in sync with a reversed version of the ObservableList.
-        transactionListView.itemsProperty().bind(Bindings.createObjectBinding(() -> {
-            ObservableList<Transaction> reversedList =
-                    FXCollections.observableArrayList(transactionList);
-            FXCollections.reverse(reversedList);
-            return reversedList;
+        /* Binds items property of the ListView to an ObservableList. Whenever the list is
+         * updated (like reversing its order), the ListView will reflect the changes. The
+         * item of the ListView is kept in sync with a reversed version of the ObservableList. */
+        transactionListView.itemsProperty()
+                .bind(
+                        Bindings.createObjectBinding(() -> {
+                            ObservableList<Transaction> reversedList =
+                                    FXCollections.observableArrayList(transactionList);
 
-        }, transactionList));
+                            FXCollections.reverse(reversedList);
+
+                            return reversedList;
+                        }, transactionList)
+            );
     }
 
     /**
@@ -53,7 +58,7 @@ public class TransactionListPanel extends UiPart<Region> {
 
         /**
          * Creates a TransactionListViewCell taking in an ObservableList
-         * parameterized to Transactions. This would later be used for retrieving the
+         * type parameterized to Transactions. This would later be used for retrieving the
          * maximum size of the transactions list which would later be used to determine
          * the correct transaction index to display, taking into account the reversed order.
          *

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -4,6 +4,7 @@
 <?import javafx.scene.layout.StackPane?>
 
 <StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
-  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..."/>
+  <TextField fx:id="commandTextField" onAction="#handleCommandEntered"
+             promptText="Enter command here..." styleClass="text-field-small-command-box"/>
 </StackPane>
 

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -29,6 +29,11 @@
     -fx-font-family: "Inter";
 }
 
+.text-field-small-command-box {
+    -fx-font-size: 8pt;
+    -fx-font-family: "Inter";
+}
+
 .tab-pane {
     -fx-padding: 0 0 0 1;
 }
@@ -337,7 +342,7 @@
     -fx-border-insets: 3;
     -fx-border-width: 1;
     -fx-font-family: "Inter";
-    -fx-font-size: 13pt;
+    -fx-font-size: 12pt;
     -fx-text-fill: #575757;
 }
 

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -343,7 +343,7 @@
     -fx-border-width: 1;
     -fx-font-family: "Inter";
     -fx-font-size: 12pt;
-    -fx-text-fill: #575757;
+    -fx-text-fill: #262626;
 }
 
 #filterField, #personListPanel, #personWebpage {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -8,10 +8,14 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.stage.*?>
 
-<fx:root minHeight="600" minWidth="450" onCloseRequest="#handleExit" title="UniCa$h" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="600" minWidth="450" onCloseRequest="#handleExit" title="UniCa$h"
+         type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17.0.2-ea"
+         xmlns:fx="http://javafx.com/fxml/1">
+
   <icons>
     <Image url="@/images/wallet_icon.png" />
   </icons>
+
   <scene>
     <Scene>
       <stylesheets>
@@ -19,7 +23,8 @@
         <URL value="@Extensions.css" />
       </stylesheets>
 
-      <VBox>
+      <VBox> <!-- Main VBox -->
+        <!-- The below code contains the MenuBar -->
         <MenuBar fx:id="menuBar" VBox.vgrow="NEVER" styleClass="bold-label-menubar">
           <Menu mnemonicParsing="false" text="File">
             <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" styleClass="normal-label" />
@@ -34,31 +39,45 @@
           </Menu>
         </MenuBar>
 
-        <!-- The below code contains the SplitPane, so the MenuBar runs across -->
-        <SplitPane dividerPositions="0.7" VBox.vgrow="ALWAYS">
-          <VBox minWidth="400" prefWidth="400" styleClass="pane-with-border">
-            <StackPane fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
-              <padding>
-                <Insets bottom="5" left="10" right="10" top="5" />
-              </padding>
-            </StackPane>
+        <!-- The below code contains the CommandBox -->
+        <VBox minWidth="400" prefWidth="400" styleClass="pane-with-border">
+          <StackPane fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
+            <padding>
+              <Insets bottom="2" left="10" right="10" top="2" />
+            </padding>
+          </StackPane>
+        </VBox>
 
+        <!-- The below code contains the Vertical SplitPane,
+        but the MenuBar and CommandBars run across -->
+        <SplitPane dividerPositions="0.7" VBox.vgrow="ALWAYS"> <!-- Start of VSplitPane -->
+
+          <!-- The below code contains the left side of the Split Pane -->
+          <VBox minWidth="400" prefWidth="400" styleClass="pane-with-border">
+
+            <!-- The below code contains the TransactionListPanel -->
             <VBox fx:id="personList" minWidth="400" prefWidth="400" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
               <padding>
-                <Insets bottom="10" left="10" right="10" top="10" />
+                <Insets bottom="8" left="10" right="10" top="8" />
               </padding>
               <StackPane fx:id="transactionListPanelPlaceholder" VBox.vgrow="ALWAYS" />
             </VBox>
+
           </VBox>
 
-          <VBox minWidth="300" prefWidth="300" styleClass="pane-with-border">
-            <StackPane fx:id="resultDisplayPlaceholder" maxHeight="310" minHeight="310" prefHeight="310" styleClass="pane-with-border">
+          <!-- The below VBox sits on the right side of the Split Pane-->
+          <VBox minWidth="300" prefWidth="300" styleClass="pane-with-border" >
+            <StackPane fx:id="resultDisplayPlaceholder" maxHeight="310" minHeight="310"
+                       prefHeight="310" styleClass="pane-with-border">
               <padding>
-                <Insets bottom="5" left="5" right="10" top="5" />
+                <Insets bottom="5" left="4" right="10" top="5" />
               </padding>
             </StackPane>
           </VBox>
-        </SplitPane>
+
+        </SplitPane> <!-- End of SplitPane -->
+
+        <!-- The below code contains the StatusBarFooter -->
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
       </VBox>
     </Scene>


### PR DESCRIPTION
### Overview 
Previously, each transaction would be appended to the bottom of the transaction list panel, which would impede the user from getting immediate feedback from their input, as the TransactionListPanel does not scroll automatically.

Rather than making the panel auto-scroll, the order of the list is reversed so that the user is always looking at the most
recent transaction, which means that the user would not have to move away from the keyboard to get a response. The index associated with each TransactionCard remains the same (i.e. reversed together in the same way), as before, i.e. there would be no change in logic required for commands that require transaction index, WYSIWYG. 

Additionally, CommandBox has been modified to span the whole Window with a smaller font size so that it can accomodate a longer input command. This would also mean that the CommandBox doesn't need to expand to occupy 2 lines as previously discussed.

<img width="929" alt="Screenshot 2023-10-21 at 9 03 50 PM" src="https://github.com/AY2324S1-CS2103-T16-3/tp/assets/19762596/2d8f23cf-cf8d-4b0e-a67a-e6e379f76ae9">

### Changes Made
- UI related FXML files and Controller classes such as MainWindow and CommandBox.
- Some minor formatting across various classes

### EDIT:
- Closing this PR as all the changes mentioned here have been subsumed into #96 