### PR TITLE
Add constraint to model

### DIFF
--- a/src/main/java/unicash/model/transaction/Amount.java
+++ b/src/main/java/unicash/model/transaction/Amount.java
@@ -26,7 +26,7 @@ public class Amount {
      * Returns true if a given amount is a non-negative value.
      */
     public static boolean isValidAmount(double amount) {
-        return amount >= 0.00 && amount <= Integer.MAX_VALUE;
+        return amount >= 0.00;
     }
 
     @Override

--- a/src/main/java/unicash/model/transaction/Amount.java
+++ b/src/main/java/unicash/model/transaction/Amount.java
@@ -26,7 +26,7 @@ public class Amount {
      * Returns true if a given amount is a non-negative value.
      */
     public static boolean isValidAmount(double amount) {
-        return amount >= 0.00;
+        return amount >= 0.00 && amount <= Integer.MAX_VALUE;
     }
 
     @Override

--- a/src/main/java/unicash/model/transaction/Location.java
+++ b/src/main/java/unicash/model/transaction/Location.java
@@ -8,14 +8,14 @@ import static unicash.commons.util.AppUtil.checkArgument;
  */
 public class Location {
     public static final String MESSAGE_CONSTRAINTS =
-            "Locations should only contain alphanumeric characters, spaces, (, ), _, -, #, &, ., and ',', "
+            "Locations should only contain alphanumeric characters, spaces, (, ), _, @, -, #, &, ., and ',', "
                     + "up to 500 characters and it should not be blank";
 
     /*
      * The first character of the location must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}_&#.,()-][\\p{Alnum} _&#.,()-]{0,499}";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}_&#.,()@-][\\p{Alnum} _&#.,()@-]{0,499}";
 
     public final String location;
 

--- a/src/main/java/unicash/model/transaction/Location.java
+++ b/src/main/java/unicash/model/transaction/Location.java
@@ -9,13 +9,13 @@ import static unicash.commons.util.AppUtil.checkArgument;
 public class Location {
     public static final String MESSAGE_CONSTRAINTS =
             "Locations should only contain alphanumeric characters, spaces, (, ), _, -, #, &, ., and ',', "
-                    + "and it should not be blank";
+                    + "up to 500 characters and it should not be blank";
 
     /*
      * The first character of the location must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}_&#.,()-][\\p{Alnum} _&#.,()-]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}_&#.,()-][\\p{Alnum} _&#.,()-]{0,499}";
 
     public final String location;
 

--- a/src/main/java/unicash/model/transaction/Name.java
+++ b/src/main/java/unicash/model/transaction/Name.java
@@ -10,14 +10,14 @@ import static unicash.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces up to 500 characters, "
-                    + "and it should not be blank";
+            "Names should only contain alphanumeric characters, spaces, (, ), _, @, -, #, &, ., and ',', "
+                    + "up to 500 characters and it should not be blank";
 
     /*
      * The first character of the transaction must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "^[\\p{Alnum}][\\p{Alnum} ]{0,499}$";
+    public static final String VALIDATION_REGEX = "^[\\p{Alnum}_&#.,()@-][\\p{Alnum} _&#.,()@-]{0,499}$";
 
     public final String fullName;
 

--- a/src/main/java/unicash/model/transaction/Name.java
+++ b/src/main/java/unicash/model/transaction/Name.java
@@ -10,13 +10,14 @@ import static unicash.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should only contain alphanumeric characters and spaces up to 500 characters, "
+                    + "and it should not be blank";
 
     /*
      * The first character of the transaction must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "^[\\p{Alnum}][\\p{Alnum} ]{0,499}$";
 
     public final String fullName;
 

--- a/src/test/java/unicash/logic/commands/CommandTestUtil.java
+++ b/src/test/java/unicash/logic/commands/CommandTestUtil.java
@@ -57,7 +57,7 @@ public class CommandTestUtil {
     public static final String LOCATION_DESC_ORCHARD = " " + PREFIX_LOCATION + VALID_LOCATION_ORCHARD;
     public static final String LOCATION_DESC_NUS = " " + PREFIX_LOCATION + VALID_LOCATION_NUS;
 
-    public static final String INVALID_TRANSACTION_NAME_DESC = " " + PREFIX_NAME + "NUS&"; // '&' not allowed in names
+    public static final String INVALID_TRANSACTION_NAME_DESC = " " + PREFIX_NAME + "NUS[]&"; // '&' not allowed in names
     public static final String INVALID_AMOUNT_DESC = " " + PREFIX_AMOUNT + "-3.0"; // negative amounts not allowed
     public static final String INVALID_DATETIME_DESC = " " + PREFIX_DATETIME + "19/13/2001 19:30"; // invalid date
     public static final String INVALID_TYPE_DESC = " " + PREFIX_TYPE + "afaf"; // invalid type

--- a/src/test/java/unicash/storage/JsonAdaptedTransactionTest.java
+++ b/src/test/java/unicash/storage/JsonAdaptedTransactionTest.java
@@ -22,11 +22,11 @@ import unicash.model.transaction.Type;
 import unicash.testutil.TransactionBuilder;
 
 public class JsonAdaptedTransactionTest {
-    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_NAME = "R@chel[]";
     private static final double INVALID_AMOUNT = -10;
     private static final String INVALID_CATEGORY = "@@@";
     private static final String INVALID_DATETIME = "hi";
-    private static final String INVALID_LOCATION = "@@@@";
+    private static final String INVALID_LOCATION = "[]@@@@";
     private static final String INVALID_TYPE = "others";
 
     private static final String VALID_NAME = SHOPPING.getName().toString();


### PR DESCRIPTION
Added constraints to validation checks in Model.
1. Maximum of 500 characters for `Name`
2. Maximum of 500 characters for `Location`
3. Maximum of `Integer.MAX_VALUE` for `Amount`

One note on `parseIndex` for values greater than `Integer.MAX_VALUE`, the parser correctly identifies and catches values greater than the limit however the error is caught by the Parser using it (`EditTransactionCommandParser`) and the custom command message constraint is returned to the user. Thus, the error of invalid integer is not fed back to the user. This might not be a bug