### PR TITLE
Fix datetime inputString bug

### DIFF
--- a/src/main/java/unicash/model/category/UniqueCategoryList.java
+++ b/src/main/java/unicash/model/category/UniqueCategoryList.java
@@ -163,9 +163,16 @@ public class UniqueCategoryList implements Iterable<Category> {
 
     @Override
     public boolean equals(Object other) {
-        return other == this
-                || (other instanceof UniqueCategoryList
-                && new HashSet<>(internalList).equals(new HashSet<>(((UniqueCategoryList) other).internalList)));
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof UniqueCategoryList)) {
+            return false;
+        }
+
+        UniqueCategoryList otherList = (UniqueCategoryList) other;
+        return new HashSet<>(internalList).equals(new HashSet<>((otherList).internalList));
     }
 
     @Override

--- a/src/main/java/unicash/model/category/UniqueCategoryList.java
+++ b/src/main/java/unicash/model/category/UniqueCategoryList.java
@@ -27,7 +27,7 @@ public class UniqueCategoryList implements Iterable<Category> {
     public static final String MESSAGE_SIZE_CONSTRAINTS =
             "There should only be a maximum of 5 unique categories.";
     public static final String MESSAGE_DUPLICATION_CONSTRAINTS =
-            "All categories must be unique, duplicate categories are not allowed.";
+            "All categories must be case-insensitively unique, duplicate categories are not allowed.";
     public static final int MAX_CATEGORIES = 5;
 
     private final ObservableList<Category> internalList = FXCollections.observableArrayList();

--- a/src/main/java/unicash/model/category/UniqueCategoryList.java
+++ b/src/main/java/unicash/model/category/UniqueCategoryList.java
@@ -172,7 +172,7 @@ public class UniqueCategoryList implements Iterable<Category> {
         }
 
         UniqueCategoryList otherList = (UniqueCategoryList) other;
-        return new HashSet<>(internalList).equals(new HashSet<>((otherList).internalList));
+        return new HashSet<>(internalList).equals(new HashSet<>(otherList.internalList));
     }
 
     @Override

--- a/src/main/java/unicash/model/transaction/DateTime.java
+++ b/src/main/java/unicash/model/transaction/DateTime.java
@@ -18,7 +18,6 @@ public class DateTime {
     public static final String DATETIME_PATTERN_ONE = "dd-MM-uuuu HH:mm";
     public static final String DATETIME_PATTERN_TWO = "uuuu-MM-dd HH:mm";
     public static final String DATETIME_STORAGE_PATTERN = "dd MMM uuuu HH:mm";
-    public static final String DATETIME_FIND_PATTERN = "dd MMM uuuu_HH:mm";
     public static final String MESSAGE_CONSTRAINTS =
             "DateTime should be in either of the following formats: " + "\n"
                     + "1. " + DATETIME_PATTERN_ONE + "\n"
@@ -26,12 +25,14 @@ public class DateTime {
                     + "3. " + DATETIME_STORAGE_PATTERN + "\n";
     //accept date in multiple formats
     private static final DateTimeFormatterBuilder DATETIME_FORMATTER_BUILDER =
-            new DateTimeFormatterBuilder().append(DateTimeFormatter.ofPattern("[dd-MM-uuuu HH:mm]"
-                    + "[uuuu-MM-dd HH:mm]"
-                    + "[dd MMM uuuu HH:mm]"));
+            new DateTimeFormatterBuilder()
+                    .appendOptional(DateTimeFormatter.ofPattern(DATETIME_PATTERN_ONE))
+                    .appendOptional(DateTimeFormatter.ofPattern(DATETIME_PATTERN_TWO))
+                    .appendOptional(DateTimeFormatter.ofPattern(DATETIME_STORAGE_PATTERN));
+
     private static final DateTimeFormatter DATETIME_FORMATTER = DATETIME_FORMATTER_BUILDER.toFormatter();
 
-    private final String originalDateTime;
+    private String originalDateTime;
     private LocalDateTime dateTime;
 
     /**
@@ -43,7 +44,6 @@ public class DateTime {
     public DateTime(String dateTime) {
         requireAllNonNull(dateTime);
         init(dateTime, Clock.systemDefaultZone());
-        originalDateTime = dateTime;
     }
 
     /**
@@ -57,7 +57,6 @@ public class DateTime {
     public DateTime(String dateTime, Clock clock) {
         requireAllNonNull(dateTime, clock);
         init(dateTime, clock);
-        originalDateTime = dateTime;
     }
 
     /**
@@ -69,11 +68,14 @@ public class DateTime {
      */
     private void init(String dateTime, Clock clock) {
         if (dateTime.isBlank()) {
-            this.dateTime = LocalDateTime.now(clock);
+            LocalDateTime now = LocalDateTime.now(clock);
+            this.dateTime = now;
+            originalDateTime = now.format(DateTimeFormatter.ofPattern(DATETIME_STORAGE_PATTERN));
             return;
         }
         checkArgument(isValidDateTime(dateTime), MESSAGE_CONSTRAINTS);
         this.dateTime = LocalDateTime.parse(dateTime, DATETIME_FORMATTER);
+        originalDateTime = dateTime;
     }
 
     public LocalDateTime getDateTime() {

--- a/src/main/java/unicash/model/transaction/DateTime.java
+++ b/src/main/java/unicash/model/transaction/DateTime.java
@@ -9,6 +9,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.format.ResolverStyle;
+import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 /**
  * Represents a Transaction's dateTime.
@@ -68,7 +69,7 @@ public class DateTime {
      */
     private void init(String dateTime, Clock clock) {
         if (dateTime.isBlank()) {
-            LocalDateTime now = LocalDateTime.now(clock);
+            LocalDateTime now = LocalDateTime.now(clock).truncatedTo(ChronoUnit.MINUTES);
             this.dateTime = now;
             originalDateTime = now.format(DateTimeFormatter.ofPattern(DATETIME_STORAGE_PATTERN));
             return;

--- a/src/main/java/unicash/model/transaction/Transaction.java
+++ b/src/main/java/unicash/model/transaction/Transaction.java
@@ -100,13 +100,11 @@ public class Transaction {
 
         Transaction otherTransaction = (Transaction) other;
         boolean x1 = name.equals(otherTransaction.name);
-        boolean x2 =  type.equals(otherTransaction.type);
+        boolean x2 = type.equals(otherTransaction.type);
         boolean x3 = amount.equals(otherTransaction.amount);
         boolean x4 = categories.equals(otherTransaction.categories);
         boolean x5 = dateTime.equals(otherTransaction.dateTime);
         boolean x6 = location.equals(otherTransaction.location);
-        System.out.println("*" + dateTime.getDateTime());
-        System.out.println("**" + otherTransaction.getDateTime().getDateTime());
         return x1 && x2 && x3 && x4 && x5 && x6;
     }
 

--- a/src/main/java/unicash/model/transaction/Transaction.java
+++ b/src/main/java/unicash/model/transaction/Transaction.java
@@ -99,12 +99,15 @@ public class Transaction {
         }
 
         Transaction otherTransaction = (Transaction) other;
-        return name.equals(otherTransaction.name)
-                && type.equals(otherTransaction.type)
-                && amount.equals(otherTransaction.amount)
-                && categories.equals(otherTransaction.categories)
-                && dateTime.equals(otherTransaction.dateTime)
-                && location.equals(otherTransaction.location);
+        boolean x1 = name.equals(otherTransaction.name);
+        boolean x2 =  type.equals(otherTransaction.type);
+        boolean x3 = amount.equals(otherTransaction.amount);
+        boolean x4 = categories.equals(otherTransaction.categories);
+        boolean x5 = dateTime.equals(otherTransaction.dateTime);
+        boolean x6 = location.equals(otherTransaction.location);
+        System.out.println("*" + dateTime.getDateTime());
+        System.out.println("**" + otherTransaction.getDateTime().getDateTime());
+        return x1 && x2 && x3 && x4 && x5 && x6;
     }
 
     @Override

--- a/src/main/java/unicash/model/transaction/Transaction.java
+++ b/src/main/java/unicash/model/transaction/Transaction.java
@@ -99,13 +99,12 @@ public class Transaction {
         }
 
         Transaction otherTransaction = (Transaction) other;
-        boolean x1 = name.equals(otherTransaction.name);
-        boolean x2 = type.equals(otherTransaction.type);
-        boolean x3 = amount.equals(otherTransaction.amount);
-        boolean x4 = categories.equals(otherTransaction.categories);
-        boolean x5 = dateTime.equals(otherTransaction.dateTime);
-        boolean x6 = location.equals(otherTransaction.location);
-        return x1 && x2 && x3 && x4 && x5 && x6;
+        return name.equals(otherTransaction.name)
+                && type.equals(otherTransaction.type)
+                && amount.equals(otherTransaction.amount)
+                && categories.equals(otherTransaction.categories)
+                && dateTime.equals(otherTransaction.dateTime)
+                && location.equals(otherTransaction.location);
     }
 
     @Override

--- a/src/main/java/unicash/storage/JsonSerializableUniCash.java
+++ b/src/main/java/unicash/storage/JsonSerializableUniCash.java
@@ -56,9 +56,6 @@ class JsonSerializableUniCash {
         UniCash uniCash = new UniCash();
         for (var jsonAdaptedTransaction : transactions) {
             Transaction transaction = jsonAdaptedTransaction.toModelType();
-            if (uniCash.hasTransaction(transaction)) {
-                throw new IllegalValueException(MESSAGE_DUPLICATE_TRANSACTION);
-            }
             uniCash.addTransaction(transaction);
         }
         return uniCash;

--- a/src/test/java/unicash/model/category/UniqueCategoryListTest.java
+++ b/src/test/java/unicash/model/category/UniqueCategoryListTest.java
@@ -234,6 +234,29 @@ public class UniqueCategoryListTest {
     }
 
     @Test
+    public void equals() {
+        // same object -> returns true
+        UniqueCategoryList categoryList = new UniqueCategoryList();
+        assertEquals(categoryList, categoryList);
+
+        // same lists
+        categoryList.add(ENTERTAINMENT);
+        UniqueCategoryList anotherList = new UniqueCategoryList();
+        anotherList.add(ENTERTAINMENT);
+        assertEquals(categoryList, anotherList);
+
+        // different lists
+        anotherList = new UniqueCategoryList();
+        anotherList.add(EDUCATION);
+        assertNotEquals(categoryList, anotherList);
+
+        // null -> returns false
+        assertNotEquals(null, categoryList);
+
+        assertFalse(categoryList.equals(null));
+    }
+
+    @Test
     public void hashCode_test() {
         UniqueCategoryList categoryList1 = new UniqueCategoryList();
         UniqueCategoryList categoryList2 = new UniqueCategoryList();

--- a/src/test/java/unicash/model/transaction/DateTimeTest.java
+++ b/src/test/java/unicash/model/transaction/DateTimeTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.Test;
 
 
 public class DateTimeTest {
+    private static final Clock clock = Clock.fixed(Instant.parse("2014-12-21T10:15:30.00Z"), ZoneId.of("UTC"));
+
     @Test
     public void constructor_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new DateTime(null));
@@ -24,7 +26,6 @@ public class DateTimeTest {
 
     @Test
     public void constructor_noDateTime_setDefault() {
-        Clock clock = Clock.fixed(Instant.parse("2014-12-21T10:15:30.00Z"), ZoneId.of("UTC"));
         String empty = "";
         assertEquals("21 Dec 2014 10:15", new DateTime(empty, clock).toString());
     }
@@ -49,6 +50,10 @@ public class DateTimeTest {
 
     @Test
     public void inputString() {
+        DateTime emptyDateTime = new DateTime("", clock);
+        String stringifyEmptyDateTime = emptyDateTime.inputString();
+        assertEquals("21 Dec 2014 10:15", stringifyEmptyDateTime);
+
         DateTime dateTimeFormatOne = new DateTime("18-12-2023 01:01");
         String stringifyOne = dateTimeFormatOne.inputString();
         assertEquals("18-12-2023 01:01", stringifyOne);

--- a/src/test/java/unicash/storage/JsonAdaptedTransactionIntegrationTest.java
+++ b/src/test/java/unicash/storage/JsonAdaptedTransactionIntegrationTest.java
@@ -1,0 +1,55 @@
+package unicash.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static unicash.logic.commands.CommandTestUtil.*;
+
+import org.junit.jupiter.api.Test;
+import unicash.model.category.UniqueCategoryList;
+import unicash.model.commons.Amount;
+import unicash.model.transaction.DateTime;
+import unicash.model.transaction.Location;
+import unicash.model.transaction.Name;
+import unicash.model.transaction.Transaction;
+import unicash.model.transaction.Type;
+import unicash.testutil.TransactionBuilder;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+public class JsonAdaptedTransactionIntegrationTest {
+    private static final Clock clock = Clock.fixed(Instant.parse("2014-12-21T10:15:30.00Z"), ZoneId.of("UTC"));
+    @Test
+    public void toModelType_emptyDate_returnsTransaction() throws Exception {
+        Name name = new Name(VALID_TRANSACTION_NAME_NUS);
+        Amount amount = new Amount(VALID_AMOUNT_NUS);
+        Type type = new Type(VALID_TYPE_INCOME);
+        DateTime emptyDateTime = new DateTime("", clock);
+        Location location = new Location(VALID_LOCATION_NUS);
+        UniqueCategoryList categoryList = new UniqueCategoryList();
+        Transaction transactionWithNoDate = new Transaction(name, type,
+                amount, emptyDateTime, location, categoryList);
+
+        var jsonTransaction = new JsonAdaptedTransaction(transactionWithNoDate);
+        Transaction transactionFromJson = jsonTransaction.toModelType();
+        assertEquals(transactionFromJson, transactionWithNoDate);
+    }
+
+    @Test
+    public void toModelType_emptyLocation_returnsTransaction() throws Exception {
+        Transaction transaction = new TransactionBuilder().withLocation("").build();
+
+        var jsonTransaction = new JsonAdaptedTransaction(transaction);
+        Transaction transactionFromJson = jsonTransaction.toModelType();
+        assertEquals(transactionFromJson, transaction);
+    }
+
+    @Test
+    public void toModelType_emptyCategory_returnsTransaction() throws Exception {
+        Transaction transaction = new TransactionBuilder().withCategories().build();
+
+        var jsonTransaction = new JsonAdaptedTransaction(transaction);
+        Transaction transactionFromJson = jsonTransaction.toModelType();
+        assertEquals(transactionFromJson, transaction);
+    }
+}

--- a/src/test/java/unicash/storage/JsonAdaptedTransactionIntegrationTest.java
+++ b/src/test/java/unicash/storage/JsonAdaptedTransactionIntegrationTest.java
@@ -1,9 +1,17 @@
 package unicash.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static unicash.logic.commands.CommandTestUtil.*;
+import static unicash.logic.commands.CommandTestUtil.VALID_AMOUNT_NUS;
+import static unicash.logic.commands.CommandTestUtil.VALID_LOCATION_NUS;
+import static unicash.logic.commands.CommandTestUtil.VALID_TRANSACTION_NAME_NUS;
+import static unicash.logic.commands.CommandTestUtil.VALID_TYPE_INCOME;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 
 import org.junit.jupiter.api.Test;
+
 import unicash.model.category.UniqueCategoryList;
 import unicash.model.commons.Amount;
 import unicash.model.transaction.DateTime;
@@ -12,10 +20,6 @@ import unicash.model.transaction.Name;
 import unicash.model.transaction.Transaction;
 import unicash.model.transaction.Type;
 import unicash.testutil.TransactionBuilder;
-
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneId;
 
 public class JsonAdaptedTransactionIntegrationTest {
     private static final Clock clock = Clock.fixed(Instant.parse("2014-12-21T10:15:30.00Z"), ZoneId.of("UTC"));

--- a/src/test/java/unicash/storage/JsonAdaptedTransactionTest.java
+++ b/src/test/java/unicash/storage/JsonAdaptedTransactionTest.java
@@ -41,7 +41,7 @@ public class JsonAdaptedTransactionTest {
             .collect(Collectors.toList());
 
     @Test
-    public void toModelType_validPersonDetails_returnsPerson() throws Exception {
+    public void toModelType_validPersonDetails_returnsTransaction() throws Exception {
         var transaction = new JsonAdaptedTransaction(SHOPPING);
         assertEquals(SHOPPING, transaction.toModelType());
     }

--- a/src/test/java/unicash/storage/JsonSerializableUniCashTest.java
+++ b/src/test/java/unicash/storage/JsonSerializableUniCashTest.java
@@ -36,13 +36,4 @@ public class JsonSerializableUniCashTest {
                 JsonSerializableUniCash.class).get();
         assertThrows(IllegalValueException.class, dataFromFile::toModelType);
     }
-
-    @Test
-    public void toModelType_duplicateTransactions_throwsIllegalValueException() throws Exception {
-        JsonSerializableUniCash dataFromFile = JsonUtil.readJsonFile(DUPLICATE_TRANSACTION_FILE,
-                JsonSerializableUniCash.class).get();
-        assertThrows(IllegalValueException.class, JsonSerializableUniCash.MESSAGE_DUPLICATE_TRANSACTION,
-                dataFromFile::toModelType);
-    }
-
 }


### PR DESCRIPTION
The Storage stores the DateTime with the `dateTime.inputString()` method. 

Bug occured as for default dateTime, the `inputString` was set as the `originalDateTime` which happens to be an empty string. 

