### PR TITLE
[Bug Fix] FindCommand bug fixed

### DIFF
--- a/src/main/java/unicash/commons/enums/CommandType.java
+++ b/src/main/java/unicash/commons/enums/CommandType.java
@@ -222,9 +222,6 @@ public enum CommandType {
                             ExampleGenerator.generate(
                                     getCommandWords(),
                                     PREFIX_NAME,
-                                    PREFIX_TYPE,
-                                    PREFIX_AMOUNT,
-                                    PREFIX_DATETIME,
                                     PREFIX_LOCATION,
                                     PREFIX_CATEGORY
                             )

--- a/src/main/java/unicash/logic/commands/FindCommand.java
+++ b/src/main/java/unicash/logic/commands/FindCommand.java
@@ -25,8 +25,8 @@ public class FindCommand extends Command {
     private static final Logger logger = Logger.getLogger("FindCommandLogger");
 
     /**
-     * Creates a {@code TransactionContainsAnyKeywordsPredicate} with a non-null
-     * predicate.
+     * Creates a {@code FindCommand} object with a non-null
+     * {@code TransactionContainsAllKeywordsPredicate} object.
      */
     public FindCommand(TransactionContainsAllKeywordsPredicate predicate) {
         requireNonNull(predicate);

--- a/src/main/java/unicash/logic/commands/FindCommand.java
+++ b/src/main/java/unicash/logic/commands/FindCommand.java
@@ -8,6 +8,9 @@ import unicash.logic.UniCashMessages;
 import unicash.model.Model;
 import unicash.model.transaction.predicates.TransactionContainsAllKeywordsPredicate;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * Finds and lists all transactions in UniCa$h whose name contains any of the argument keywords.
  * Keyword matching is case-insensitive.
@@ -18,6 +21,8 @@ public class FindCommand extends Command {
     public static final String MESSAGE_USAGE = CommandType.FIND.getMessageUsage();
 
     private final TransactionContainsAllKeywordsPredicate predicate;
+
+    private static final Logger logger = Logger.getLogger("FindCommandLogger");
 
     /**
      * Creates a {@code TransactionContainsAnyKeywordsPredicate} with a non-null
@@ -32,7 +37,14 @@ public class FindCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         assert predicate != null : "predicate cannot be null";
+
         model.updateFilteredTransactionList(predicate);
+
+        logger.log(Level.INFO, String.format(
+                "Transaction List successfully updated with the predicate %s", predicate));
+
+        logger.log(Level.INFO, "Find command executed successfully");
+
         return new CommandResult(
                 String.format(UniCashMessages.MESSAGE_TRANSACTIONS_LISTED_OVERVIEW,
                         model.getFilteredTransactionList().size()));

--- a/src/main/java/unicash/logic/commands/FindCommand.java
+++ b/src/main/java/unicash/logic/commands/FindCommand.java
@@ -2,14 +2,16 @@ package unicash.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import unicash.commons.enums.CommandType;
 import unicash.commons.util.ToStringBuilder;
 import unicash.logic.UniCashMessages;
 import unicash.model.Model;
 import unicash.model.transaction.predicates.TransactionContainsAllKeywordsPredicate;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
+
 
 /**
  * Finds and lists all transactions in UniCa$h whose name contains any of the argument keywords.
@@ -20,10 +22,11 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = CommandType.FIND.getCommandWords();
     public static final String MESSAGE_USAGE = CommandType.FIND.getMessageUsage();
 
-    private final TransactionContainsAllKeywordsPredicate predicate;
-
     private static final Logger logger = Logger.getLogger("FindCommandLogger");
 
+    private final TransactionContainsAllKeywordsPredicate predicate;
+
+    
     /**
      * Creates a {@code FindCommand} object with a non-null
      * {@code TransactionContainsAllKeywordsPredicate} object.

--- a/src/main/java/unicash/logic/commands/FindCommand.java
+++ b/src/main/java/unicash/logic/commands/FindCommand.java
@@ -26,10 +26,12 @@ public class FindCommand extends Command {
 
     private final TransactionContainsAllKeywordsPredicate predicate;
 
-    
+
     /**
      * Creates a {@code FindCommand} object with a non-null
      * {@code TransactionContainsAllKeywordsPredicate} object.
+     *
+     * @param predicate the {@code TransactionContainsAllKeywordsPredicate} to be used
      */
     public FindCommand(TransactionContainsAllKeywordsPredicate predicate) {
         requireNonNull(predicate);

--- a/src/main/java/unicash/logic/parser/FindCommandParser.java
+++ b/src/main/java/unicash/logic/parser/FindCommandParser.java
@@ -55,6 +55,9 @@ public class FindCommandParser implements Parser<FindCommand> {
                 args, PREFIX_NAME, PREFIX_CATEGORY, PREFIX_LOCATION);
 
         String trimmedArgs = args.trim();
+
+        /* Throws a ParseException if the argument does not contain any non-whitespace characters
+         * or if there are any non-whitespace characters preceding the first valid prefix */
         if (trimmedArgs.isEmpty() || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
@@ -64,18 +67,21 @@ public class FindCommandParser implements Parser<FindCommand> {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_CATEGORY, PREFIX_LOCATION);
 
 
+        /* If present, add the argument following the Name prefix as a name predicate keyword */
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             Name transactionName = ParserUtil.parseTransactionName(
                     argMultimap.getValue(PREFIX_NAME).get());
             findPredicate.addNameKeyword(transactionName.toString());
         }
 
+        /* If present, add the argument following the Category prefix as a category predicate keyword */
         if (argMultimap.getValue(PREFIX_CATEGORY).isPresent()) {
             Category transactionCategory = ParserUtil.parseCategory(
                     argMultimap.getValue(PREFIX_CATEGORY).get());
             findPredicate.addCategoryKeyword(transactionCategory.toString());
         }
 
+        /* If present, add the argument following the Location prefix as a location predicate keyword */
         if (argMultimap.getValue(PREFIX_LOCATION).isPresent()) {
             Location transactionLocation = ParserUtil.parseLocation(
                     argMultimap.getValue(PREFIX_LOCATION).get());
@@ -112,8 +118,12 @@ public class FindCommandParser implements Parser<FindCommand> {
     /**
      * Returns true if any of the prefixes contains any {@code Optional} values in the given
      * {@code ArgumentMultimap}.
+     *
+     * @param argumentMultimap the input {@code ArgumentMultimap}
+     * @param prefixes the input prefixes to check with the {@code ArgumentMultimap}
+     * @return true if any input prefix is present in {@code ArgumentMultimap}, false otherwise
      */
-    private static boolean areAnyPrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+    public static boolean areAnyPrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes)
                 .anyMatch(prefix -> argumentMultimap
                         .getValue(prefix)

--- a/src/main/java/unicash/logic/parser/FindCommandParser.java
+++ b/src/main/java/unicash/logic/parser/FindCommandParser.java
@@ -38,26 +38,20 @@ public class FindCommandParser implements Parser<FindCommand> {
         requireNonNull(args);
 
         /* All prefixes are parsed first */
-        ArgumentMultimap argMultimapWithAllPrefixes = ArgumentTokenizer.tokenize(args, PREFIX_NAME,
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME,
                 PREFIX_DATETIME, PREFIX_AMOUNT, PREFIX_TYPE, PREFIX_CATEGORY, PREFIX_LOCATION);
 
         /* If any of the invalid prefixes are present, an invalid command format message
          * is displayed to the user, as opposed to the invalid prefixes themselves being
          * parsed together with the valid prefixes as a standard field input. */
         if (areAnyPrefixesPresent(
-                argMultimapWithAllPrefixes, PREFIX_DATETIME, PREFIX_AMOUNT, PREFIX_TYPE)) {
+                argMultimap, PREFIX_DATETIME, PREFIX_AMOUNT, PREFIX_TYPE)) {
 
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
-                args, PREFIX_NAME, PREFIX_CATEGORY, PREFIX_LOCATION);
-
         String trimmedArgs = args.trim();
-
-        /* Throws a ParseException if the argument does not contain any non-whitespace characters
-         * or if there are any non-whitespace characters preceding the first valid prefix */
         if (trimmedArgs.isEmpty() || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));

--- a/src/main/java/unicash/logic/parser/FindCommandParser.java
+++ b/src/main/java/unicash/logic/parser/FindCommandParser.java
@@ -2,9 +2,14 @@ package unicash.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static unicash.logic.UniCashMessages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static unicash.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static unicash.logic.parser.CliSyntax.PREFIX_CATEGORY;
+import static unicash.logic.parser.CliSyntax.PREFIX_DATETIME;
 import static unicash.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static unicash.logic.parser.CliSyntax.PREFIX_NAME;
+import static unicash.logic.parser.CliSyntax.PREFIX_TYPE;
+
+import java.util.stream.Stream;
 
 import unicash.commons.util.ToStringBuilder;
 import unicash.logic.commands.FindCommand;
@@ -31,6 +36,21 @@ public class FindCommandParser implements Parser<FindCommand> {
      */
     public FindCommand parse(String args) throws ParseException {
         requireNonNull(args);
+
+        /* All prefixes are parsed first */
+        ArgumentMultimap argMultimapWithAllPrefixes = ArgumentTokenizer.tokenize(args, PREFIX_NAME,
+                PREFIX_DATETIME, PREFIX_AMOUNT, PREFIX_TYPE, PREFIX_CATEGORY, PREFIX_LOCATION);
+
+        /* If any of the invalid prefixes are present, an invalid command format message
+         * is displayed to the user, as opposed to the invalid prefixes themselves being
+         * parsed together with the valid prefixes as a standard field input. */
+        if (areAnyPrefixesPresent(
+                argMultimapWithAllPrefixes, PREFIX_DATETIME, PREFIX_AMOUNT, PREFIX_TYPE)) {
+
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
                 args, PREFIX_NAME, PREFIX_CATEGORY, PREFIX_LOCATION);
 
@@ -40,6 +60,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
+        /* Enforces singular prefix input by the user */
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_CATEGORY, PREFIX_LOCATION);
 
 
@@ -60,6 +81,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                     argMultimap.getValue(PREFIX_LOCATION).get());
             findPredicate.addLocationKeyword(transactionLocation.toString());
         }
+
         return new FindCommand(findPredicate);
 
     }
@@ -85,6 +107,17 @@ public class FindCommandParser implements Parser<FindCommand> {
         return new ToStringBuilder(this)
                 .add("findPredicate", findPredicate)
                 .toString();
+    }
+
+    /**
+     * Returns true if any of the prefixes contains any {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean areAnyPrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes)
+                .anyMatch(prefix -> argumentMultimap
+                        .getValue(prefix)
+                        .isPresent());
     }
 
 }

--- a/src/main/java/unicash/model/transaction/predicates/TransactionCategoryContainsKeywordsPredicate.java
+++ b/src/main/java/unicash/model/transaction/predicates/TransactionCategoryContainsKeywordsPredicate.java
@@ -13,16 +13,29 @@ import unicash.model.transaction.Transaction;
  */
 public class TransactionCategoryContainsKeywordsPredicate
         implements Predicate<Transaction> {
+
     private final List<String> keywords;
 
+    /**
+     * Creates a new {@code TransactionCategoryContainsKeywordsPredicate} object
+     * with the given list of string keywords.
+     *
+     * @param keywords the input list of keywords to be matched
+     */
     public TransactionCategoryContainsKeywordsPredicate(List<String> keywords) {
         this.keywords = keywords;
     }
 
-    /* A nested anyMatch compares each keyword for each category in the categoryList.
-     * This removes any String dependency entirely so the keyword "od,so" now will not
-     * match something like "food,social" compared to if the string representation
-     * of the categoryList was returned.
+    /**
+     * Returns true if any {@code Category} within the {@code UniqueCategoryList}
+     * of the Transaction contains any of the keywords in the keywords list
+     * as a substring.
+     *
+     * <p> A nested anyMatch compares each keyword for each category directly in the
+     * {@code UniqueCategoryList}. This removes any dependency on {@code UniqueCategoryList}'s
+     * representation of the Categories.
+     *
+     * @param transaction the input {@code Transaction} object to be tested
      */
     @Override
     public boolean test(Transaction transaction) {
@@ -58,6 +71,8 @@ public class TransactionCategoryContainsKeywordsPredicate
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).add("keywords", keywords).toString();
+        return new ToStringBuilder(this)
+                .add("keywords", keywords)
+                .toString();
     }
 }

--- a/src/main/java/unicash/model/transaction/predicates/TransactionContainsAllKeywordsPredicate.java
+++ b/src/main/java/unicash/model/transaction/predicates/TransactionContainsAllKeywordsPredicate.java
@@ -10,31 +10,47 @@ import unicash.model.transaction.Transaction;
 
 
 /**
- * Tests that the {@code Transactions}'s properties matches all the keywords given.
+ * Tests that the {@code Transaction}'s properties matches all the keywords given.
  * Matching in this context either means a partial match of the keyword with the query, or
  * a full match of the keyword, repeated for each keyword present in the list of keywords.
  *
- * </p> The matching depends on the property of the Transaction being matched, and the
+ * </p> The matching depends on the property of the {@code Transaction} being matched, and the
  * most appropriate matching is specified within the associated property predicate. This class
  * simulates a composed predicate that represents a short-circuiting logical AND of all property
  * predicates.
  *
  * </p> Encapsulated within is a list of transaction predicates, and this list can be accessed
- * publicly, and modified. The test method returns true only if the input Transaction matches
- * all predicates in this list.
+ * publicly, and modified. The overriding test method returns true only if the input Transaction
+ * matches all predicates in this list.
  */
 public class TransactionContainsAllKeywordsPredicate implements Predicate<Transaction> {
 
     private List<Predicate<Transaction>> predicateList;
 
+    /**
+     * Creates a new {@code TransactionContainsAllKeywordsPredicate} object with a
+     * default empty list of transaction predicates.
+     */
     public TransactionContainsAllKeywordsPredicate() {
         this.predicateList = new ArrayList<>();
     }
 
+    /**
+     * Creates a new {@code TransactionContainsAllKeywordsPredicate} object with the
+     * given list of transaction predicates.
+     *
+     * @param predicateList
+     */
     public TransactionContainsAllKeywordsPredicate(List<Predicate<Transaction>> predicateList) {
         this.predicateList = predicateList;
     }
 
+    /**
+     * Returns true if the input {@code Transaction} object matches
+     * all transaction predicates within the encapsulated {@code predicateList}.
+     *
+     * @param transaction the input {@code Transaction} object to be tested
+     */
     @Override
     public boolean test(Transaction transaction) {
         if (predicateList.isEmpty()) {
@@ -95,7 +111,9 @@ public class TransactionContainsAllKeywordsPredicate implements Predicate<Transa
 
     /**
      * A helper method that returns the input string keyword as a list
-     * with a single item.
+     * with a single item. This allows for multiple words in an input
+     * argument to be treated as a single, unified string, whitespace
+     * notwithstanding.
      *
      * @param keyword the input keyword String
      * @return the keyword as a single List.

--- a/src/main/java/unicash/model/transaction/predicates/TransactionLocationContainsKeywordsPredicate.java
+++ b/src/main/java/unicash/model/transaction/predicates/TransactionLocationContainsKeywordsPredicate.java
@@ -12,12 +12,25 @@ import unicash.model.transaction.Transaction;
  */
 public class TransactionLocationContainsKeywordsPredicate
         implements Predicate<Transaction> {
+
     private final List<String> keywords;
 
+    /**
+     * Creates a new {@code TransactionLocationContainsKeywordsPredicate} object
+     * with the given list of string keywords.
+     *
+     * @param keywords the input list of keywords to be matched
+     */
     public TransactionLocationContainsKeywordsPredicate(List<String> keywords) {
         this.keywords = keywords;
     }
 
+    /**
+     * Returns true if the {@code Location} of the Transaction contains any of
+     * the keywords in the keywords list as a substring.
+     *
+     * @param transaction the input {@code Transaction} object to be tested
+     */
     @Override
     public boolean test(Transaction transaction) {
         return keywords.stream()
@@ -43,6 +56,8 @@ public class TransactionLocationContainsKeywordsPredicate
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).add("keywords", keywords).toString();
+        return new ToStringBuilder(this)
+                .add("keywords", keywords)
+                .toString();
     }
 }

--- a/src/main/java/unicash/model/transaction/predicates/TransactionNameContainsKeywordsPredicate.java
+++ b/src/main/java/unicash/model/transaction/predicates/TransactionNameContainsKeywordsPredicate.java
@@ -12,12 +12,25 @@ import unicash.model.transaction.Transaction;
  */
 public class TransactionNameContainsKeywordsPredicate
         implements Predicate<Transaction> {
+
     private final List<String> keywords;
 
+    /**
+     * Creates a new {@code TransactionNameContainsKeywordsPredicate} object
+     * with the given list of string keywords.
+     *
+     * @param keywords the input list of keywords to be matched
+     */
     public TransactionNameContainsKeywordsPredicate(List<String> keywords) {
         this.keywords = keywords;
     }
 
+    /**
+     * Returns true if the {@code Name} of the Transaction contains any of
+     * the keywords in the keywords list as a substring.
+     *
+     * @param transaction the input {@code Transaction} object to be tested
+     */
     @Override
     public boolean test(Transaction transaction) {
         return keywords.stream()
@@ -43,7 +56,9 @@ public class TransactionNameContainsKeywordsPredicate
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).add("keywords", keywords).toString();
+        return new ToStringBuilder(this)
+                .add("keywords", keywords)
+                .toString();
     }
 }
 

--- a/src/main/java/unicash/ui/HelpWindow.java
+++ b/src/main/java/unicash/ui/HelpWindow.java
@@ -15,7 +15,7 @@ import unicash.commons.core.LogsCenter;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USER_GUIDE_URL = "https://ay2324s1-cs2103-t16-3.github.io/tp/";
+    public static final String USER_GUIDE_URL = "https://ay2324s1-cs2103-t16-3.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USER_GUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);

--- a/src/test/java/unicash/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/unicash/logic/parser/FindCommandParserTest.java
@@ -1,6 +1,7 @@
 package unicash.logic.parser;
 
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -15,6 +16,7 @@ import static unicash.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+import unicash.commons.enums.CommandType;
 import unicash.commons.util.ToStringBuilder;
 import unicash.logic.UniCashMessages;
 import unicash.logic.parser.exceptions.ParseException;
@@ -28,7 +30,9 @@ import unicash.model.transaction.predicates.TransactionContainsAllKeywordsPredic
  */
 public class FindCommandParserTest {
 
+    private static final String WHITESPACE = " ";
     private final FindCommandParser parser = new FindCommandParser();
+    private final UniCashParser uniCashParser = new UniCashParser();
 
     @Test
     public void parse_emptyArg_throwsParseException() {
@@ -86,8 +90,111 @@ public class FindCommandParserTest {
                 new TransactionContainsAllKeywordsPredicate();
 
         String expected = new ToStringBuilder(new FindCommandParser())
-                .add("findPredicate", findPredicate).toString();
+                .add("findPredicate", findPredicate)
+                .toString();
+
         assertEquals(expected, findCommandParser.toString());
     }
+
+    @Test
+    public void parseMethod_inputContainsDateTimePrefix_throwsException() {
+        String dateTimePrefixedArgument = "dt/10-10-2023 10:10";
+        String findCommandArgumentWithDateTime =
+                CommandType.FIND.getMainCommandWord()
+                        + WHITESPACE + dateTimePrefixedArgument;
+
+        assertThrows(ParseException.class, () -> {
+            uniCashParser.parseCommand(findCommandArgumentWithDateTime);
+        });
+
+        assertThrows(ParseException.class, () -> {
+            parser.parse(WHITESPACE + findCommandArgumentWithDateTime);
+        });
+    }
+
+    @Test
+    public void parseMethod_inputContainsTypePrefix_throwsException() {
+        String typePrefixedArgument = "type/expense";
+        String findCommandArgumentWithType =
+                CommandType.FIND.getMainCommandWord()
+                        + WHITESPACE + typePrefixedArgument;
+
+        assertThrows(ParseException.class, () -> {
+            uniCashParser.parseCommand(findCommandArgumentWithType);
+        });
+
+        assertThrows(ParseException.class, () -> {
+            parser.parse(WHITESPACE + typePrefixedArgument);
+        });
+    }
+
+    @Test
+    public void parseMethod_inputContainsAmountPrefix_throwsException() {
+        String amountPrefixedArgument = "amt/30.00";
+        String findCommandArgumentWithAmount =
+                CommandType.FIND.getMainCommandWord()
+                        + WHITESPACE + amountPrefixedArgument;
+
+        assertThrows(ParseException.class, () -> {
+            uniCashParser.parseCommand(findCommandArgumentWithAmount);
+        });
+
+        assertThrows(ParseException.class, () -> {
+            parser.parse(WHITESPACE + amountPrefixedArgument);
+        });
+
+    }
+
+    @Test
+    public void parseMethod_inputContainsNamePrefix_doesNotThrowsException() {
+        String namePrefixedArgument = "n/buying eggs";
+        String findCommandArgumentWithName =
+                CommandType.FIND.getMainCommandWord()
+                        + WHITESPACE + namePrefixedArgument;
+
+        assertDoesNotThrow(() -> {
+            uniCashParser.parseCommand(findCommandArgumentWithName);
+        });
+
+        assertDoesNotThrow(() -> {
+            parser.parse(WHITESPACE + namePrefixedArgument);
+        });
+
+    }
+
+    @Test
+    public void parseMethod_inputContainsCategoryPrefix_doesNotThrowsException() {
+        String categoryPrefixedArgument = "c/food";
+        String findCommandArgumentWithCategory =
+                CommandType.FIND.getMainCommandWord()
+                        + WHITESPACE + categoryPrefixedArgument;
+
+        assertDoesNotThrow(() -> {
+            uniCashParser.parseCommand(findCommandArgumentWithCategory);
+        });
+
+        assertDoesNotThrow(() -> {
+            parser.parse(WHITESPACE + categoryPrefixedArgument);
+        });
+
+    }
+
+    @Test
+    public void parseMethod_inputContainsLocationPrefix_doesNotThrowsException() {
+        String locationPrefixedArgument = "l/mall";
+        String findCommandArgumentWithLocation =
+                CommandType.FIND.getMainCommandWord()
+                        + WHITESPACE + locationPrefixedArgument;
+
+        assertDoesNotThrow(() -> {
+            uniCashParser.parseCommand(findCommandArgumentWithLocation);
+        });
+
+        assertDoesNotThrow(() -> {
+            parser.parse(WHITESPACE + locationPrefixedArgument);
+        });
+
+    }
+
 
 }

--- a/src/test/java/unicash/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/unicash/logic/parser/FindCommandParserTest.java
@@ -97,7 +97,7 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parseMethod_inputContainsDateTimePrefix_throwsException() {
+    public void parseMethod_inputContainsDateTimePrefix_throwsParseException() {
         String dateTimePrefixedArgument = "dt/10-10-2023 10:10";
         String findCommandArgumentWithDateTime =
                 CommandType.FIND.getMainCommandWord()
@@ -113,7 +113,7 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parseMethod_inputContainsTypePrefix_throwsException() {
+    public void parseMethod_inputContainsTypePrefix_throwsParseException() {
         String typePrefixedArgument = "type/expense";
         String findCommandArgumentWithType =
                 CommandType.FIND.getMainCommandWord()
@@ -129,7 +129,7 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parseMethod_inputContainsAmountPrefix_throwsException() {
+    public void parseMethod_inputContainsAmountPrefix_throwsParseException() {
         String amountPrefixedArgument = "amt/30.00";
         String findCommandArgumentWithAmount =
                 CommandType.FIND.getMainCommandWord()
@@ -146,7 +146,7 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parseMethod_inputContainsNamePrefix_doesNotThrowsException() {
+    public void parseMethod_inputContainsNamePrefix_doesNotThrowsParseException() {
         String namePrefixedArgument = "n/buying eggs";
         String findCommandArgumentWithName =
                 CommandType.FIND.getMainCommandWord()
@@ -163,7 +163,7 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parseMethod_inputContainsCategoryPrefix_doesNotThrowsException() {
+    public void parseMethod_inputContainsCategoryPrefix_doesNotThrowsParseException() {
         String categoryPrefixedArgument = "c/food";
         String findCommandArgumentWithCategory =
                 CommandType.FIND.getMainCommandWord()
@@ -180,7 +180,7 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parseMethod_inputContainsLocationPrefix_doesNotThrowsException() {
+    public void parseMethod_inputContainsLocationPrefix_doesNotThrowsParseException() {
         String locationPrefixedArgument = "l/mall";
         String findCommandArgumentWithLocation =
                 CommandType.FIND.getMainCommandWord()


### PR DESCRIPTION
### Main
- Fixed the bug in FindCommandParser that caused the wrong input prefixes to be parsed as normal
- Found another bug in FindCommand that showed the wrong error message and fixed it

### Others
- Added some proper JavaDocs to related classes especially for the Transaction Predicates
- Added a logger inside FindCommand (for the course requirements)
- Fixed coding style issues here and there (in the above classes only)
- Edit: Added the HelpWindow URL as well, since it was only one line to change

### Tests
- Wrote some tests for the updated FindCommandParser for codecov

This resolves report (17) in the google sheets (and like 5 other bugs)