### PR TITLE
Refactor code to utilize CommandType enum

### DIFF
--- a/src/main/java/unicash/commons/enums/CommandType.java
+++ b/src/main/java/unicash/commons/enums/CommandType.java
@@ -232,7 +232,7 @@ public enum CommandType {
 
         @Override
         public String getMessageSuccess() {
-            return "Found %1$d transactions:\n\n%2$s";
+            return "%1$d transactions listed!";
         }
     },
     GET("get", "g") {
@@ -398,7 +398,7 @@ public enum CommandType {
     }
 
     public String getMessageFailure() {
-        return "Command not recognised. Try using the command " + getMainCommandWord()
+        return "Command not recognised. Try using the command " + getCommandWords()
                 + " without any parameters instead.";
     }
 

--- a/src/main/java/unicash/logic/commands/FindCommand.java
+++ b/src/main/java/unicash/logic/commands/FindCommand.java
@@ -7,7 +7,6 @@ import java.util.logging.Logger;
 
 import unicash.commons.enums.CommandType;
 import unicash.commons.util.ToStringBuilder;
-import unicash.logic.UniCashMessages;
 import unicash.model.Model;
 import unicash.model.transaction.predicates.TransactionContainsAllKeywordsPredicate;
 
@@ -21,6 +20,7 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = CommandType.FIND.getCommandWords();
     public static final String MESSAGE_USAGE = CommandType.FIND.getMessageUsage();
+    public static final String MESSAGE_SUCCESS = CommandType.FIND.getMessageSuccess();
 
     private static final Logger logger = Logger.getLogger("FindCommandLogger");
 
@@ -51,8 +51,7 @@ public class FindCommand extends Command {
         logger.log(Level.INFO, "Find command executed successfully");
 
         return new CommandResult(
-                String.format(UniCashMessages.MESSAGE_TRANSACTIONS_LISTED_OVERVIEW,
-                        model.getFilteredTransactionList().size()));
+                String.format(MESSAGE_SUCCESS, model.getFilteredTransactionList().size()));
     }
 
     @Override

--- a/src/main/java/unicash/logic/commands/GetCommand.java
+++ b/src/main/java/unicash/logic/commands/GetCommand.java
@@ -25,8 +25,7 @@ public class GetCommand extends Command {
 
     public static final String MESSAGE_USAGE = CommandType.GET.getMessageUsage();
 
-    public static final String MESSAGE_GET_TRANSACTION_SUCCESS = "Transaction %1$d retrieved:"
-            + "\n\n%2$s";
+    public static final String MESSAGE_GET_TRANSACTION_SUCCESS = CommandType.GET.getMessageSuccess();
 
     private static final Logger logger = Logger.getLogger("GetCommandLogger");
 

--- a/src/main/java/unicash/logic/commands/ListCommand.java
+++ b/src/main/java/unicash/logic/commands/ListCommand.java
@@ -19,10 +19,9 @@ public class ListCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = CommandType.LIST.getMessageSuccess();
 
-    private static final Logger logger = Logger.getLogger("ListCommandLogger");
+    public static final String MESSAGE_FAILURE = CommandType.LIST.getMessageFailure();
 
-    public static final String MESSAGE_FAILURE = "Command not recognised. Try using the command " + COMMAND_WORD
-            + " without any parameters instead.";
+    private static final Logger logger = Logger.getLogger("ListCommandLogger");
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/test/java/unicash/logic/commands/FindCommandTest.java
+++ b/src/test/java/unicash/logic/commands/FindCommandTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static unicash.logic.UniCashMessages.MESSAGE_TRANSACTIONS_LISTED_OVERVIEW;
 import static unicash.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static unicash.testutil.Assert.assertThrows;
 import static unicash.testutil.TypicalTransactions.INTERN;
@@ -19,6 +18,7 @@ import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
+import unicash.commons.enums.CommandType;
 import unicash.model.Model;
 import unicash.model.ModelManager;
 import unicash.model.UniCash;
@@ -66,7 +66,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_zeroKeywords_noTransactionsFound() {
-        String expectedMessage = String.format(MESSAGE_TRANSACTIONS_LISTED_OVERVIEW, 0);
+        String expectedMessage = String.format(CommandType.FIND.getMessageSuccess(), 0);
         TransactionContainsAllKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredTransactionList(predicate);
@@ -76,7 +76,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_oneKeyword_multipleTransactionsFound() {
-        String expectedMessage = String.format(MESSAGE_TRANSACTIONS_LISTED_OVERVIEW, 3);
+        String expectedMessage = String.format(CommandType.FIND.getMessageSuccess(), 3);
         TransactionContainsAllKeywordsPredicate predicate = preparePredicate("work");
         FindCommand command = new FindCommand(predicate);
 


### PR DESCRIPTION
Missed out a few usages for `List`, `Get` and `Find` commands during previous refactor, and thus have updated it accordingly. This should boost code cov slightly. There should be **no changes** to message output, as per feature freeze rules. (Any change is _completely unintentional_, reviewer for this PR can hopefully help to double check!)