### PR TITLE
[Bug Fix] Fix bug in Reset & Clear Command

### DIFF
--- a/src/main/java/unicash/logic/commands/ClearTransactionsCommand.java
+++ b/src/main/java/unicash/logic/commands/ClearTransactionsCommand.java
@@ -3,13 +3,13 @@ package unicash.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static unicash.model.Model.PREDICATE_SHOW_ALL_TRANSACTIONS;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import unicash.commons.enums.CommandType;
 import unicash.commons.util.ToStringBuilder;
 import unicash.model.Model;
 import unicash.model.UniCash;
-
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Clears all transactions in UniCash.

--- a/src/main/java/unicash/logic/commands/ClearTransactionsCommand.java
+++ b/src/main/java/unicash/logic/commands/ClearTransactionsCommand.java
@@ -1,11 +1,15 @@
 package unicash.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static unicash.model.Model.PREDICATE_SHOW_ALL_TRANSACTIONS;
 
 import unicash.commons.enums.CommandType;
 import unicash.commons.util.ToStringBuilder;
 import unicash.model.Model;
 import unicash.model.UniCash;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Clears all transactions in UniCash.
@@ -17,11 +21,15 @@ public class ClearTransactionsCommand extends Command {
     public static final String MESSAGE_USAGE = CommandType.CLEAR_TRANSACTIONS.getMessageUsage();
     public static final String MESSAGE_FAILURE = CommandType.CLEAR_TRANSACTIONS.getMessageFailure();
 
+    private static final Logger logger = Logger.getLogger("ClearCommandLogger");
+
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setUniCash(new UniCash());
+        model.updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
+        logger.log(Level.INFO, "Successfully cleared all transactions in UniCash!");
         return new CommandResult(MESSAGE_SUCCESS);
     }
 

--- a/src/main/java/unicash/logic/commands/ResetCommand.java
+++ b/src/main/java/unicash/logic/commands/ResetCommand.java
@@ -4,12 +4,13 @@ import static java.util.Objects.requireNonNull;
 import static unicash.model.Model.PREDICATE_SHOW_ALL_TRANSACTIONS;
 import static unicash.model.util.SampleDataUtil.getSampleUniCash;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import unicash.commons.enums.CommandType;
 import unicash.commons.util.ToStringBuilder;
 import unicash.model.Model;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Resets UniCash to initial state by replacing the current UniCash

--- a/src/main/java/unicash/logic/commands/ResetCommand.java
+++ b/src/main/java/unicash/logic/commands/ResetCommand.java
@@ -1,15 +1,19 @@
 package unicash.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static unicash.model.Model.PREDICATE_SHOW_ALL_TRANSACTIONS;
 import static unicash.model.util.SampleDataUtil.getSampleUniCash;
 
 import unicash.commons.enums.CommandType;
 import unicash.commons.util.ToStringBuilder;
 import unicash.model.Model;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
- * Resets UniCa$h to initial state by replacing the current UniCa$h
- * storage data and populating it with the default UniCa$h containing
+ * Resets UniCash to initial state by replacing the current UniCash
+ * storage data and populating it with the default UniCash containing
  * typical transactions from {@code SampleDataUtil}.
  */
 public class ResetCommand extends Command {
@@ -20,11 +24,15 @@ public class ResetCommand extends Command {
 
     public static final String MESSAGE_FAILURE = CommandType.RESET.getMessageFailure();
 
+    private static final Logger logger = Logger.getLogger("ResetCommandLogger");
+
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setUniCash(getSampleUniCash());
+        model.updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
+        logger.log(Level.INFO, "Successfully reset UniCash!");
         return new CommandResult(MESSAGE_SUCCESS);
     }
 


### PR DESCRIPTION
### Main
-  Make the reset and clear commands update the filtered list after being executed.


### Minor
- Logging & JavaDocs

### How to replicate

1.  reset_unicash
2.  add_transaction  `add n/friends type/expense amt/300 dt/18-08-2023 19:30 l/NTUC c/Food`
3.  find n/friends -> will show 2 transactions
4.  reset_unicash again -> shows only 1 transaction (the filtered list is still active)
5.  list -> now shows all default transactions

---


1. reset_unicash 
2. find n/friends -> will show 1 transactions
3. clear_transactions
4. reset_unicash again -> shows only 1 transaction (the filtered list is still active)
5. list -> now shows all default transactions


In both cases, logically the filteredTransactionList shouldn't be active after resetting/clearing unicash


### Important
- Edit: Another possible bug - Reset_unicash is supposed to restore UniCash to original state but budget still persists, would it make more sense to clear budget as well? Could be considered a functionality bug, not sure if it constitutes feature change though the fix would be a one-liner. 