### PR TITLE
Fix find example bug

### DIFF
--- a/src/main/java/unicash/commons/enums/CommandType.java
+++ b/src/main/java/unicash/commons/enums/CommandType.java
@@ -220,7 +220,7 @@ public enum CommandType {
                     .addParameter(PREFIX_CATEGORY, "Category", true, false)
                     .setExample(
                             ExampleGenerator.generate(
-                                    getCommandWords(),
+                                    getMainCommandWord(),
                                     PREFIX_NAME,
                                     PREFIX_LOCATION,
                                     PREFIX_CATEGORY


### PR DESCRIPTION
before fix:
<img width="451" alt="image" src="https://github.com/AY2324S1-CS2103-T16-3/tp/assets/64241899/67cf0936-2955-4b78-afb8-664f16cef5da">

after fix:
<img width="451" alt="image" src="https://github.com/AY2324S1-CS2103-T16-3/tp/assets/64241899/e69df159-9228-4103-a488-bfde56778cbb">


Reason it is a bug & needs to be fixed:
- all other commands only display 1 command word, using `getMainCommandWord()`, so this difference makes the messages inconsistent.
- the example command should allow users to directly copy & paste and for it to work without issues, however without this fix it will be flagged out as incorrect formatting (which it is, since it has multiple command keywords), making the example inaccurate.

I will update this after I receive a reply from Prof in the forum to double check! Link to it is [here](https://github.com/nus-cs2103-AY2324S1/forum/issues/458)